### PR TITLE
Feature/#36 non standard shifted keys

### DIFF
--- a/firmware/keyboard/ergodox/layout/fragments/keys.part.h
+++ b/firmware/keyboard/ergodox/layout/fragments/keys.part.h
@@ -21,6 +21,12 @@
     void P(name) (void) { KF(press)(value); }   \
     void R(name) (void) { KF(release)(value); }
 
+/**                                            macros/TYPE__DEFAULT/description
+ * Define the functions for a default key (i.e. a normal key that presses and
+ * releases a keycode as you'd expect). Other than KEYS_DEFAULT, this does send
+ * a press and release event on key press and does not wait for the user
+ * releasing the key.
+ */
 #define  TYPE__DEFAULT(name, value)                   \
     void P(name) (void) { KF(press)(value);           \
                           usb__kb__send_report();     \
@@ -39,6 +45,12 @@
     void R(name) (void) { KF(release)(value);                   \
                           KF(release)(KEYBOARD__LeftShift); }
 
+/**                                            macros/TYPE__SHIFTED/description
+ * Define the functions for a "shifted" key (i.e. a key that sends a "shift"
+ * along with the keycode). Other than KEYS_SHIFTED, this does send
+ * a press and release event on key press and does not wait for the user
+ * releasing the key.
+ */
 #define  TYPE__SHIFTED(name, value)                             \
     void P(name) (void) { KF(press)(KEYBOARD__LeftShift);       \
                           usb__kb__send_report();               \
@@ -50,9 +62,7 @@
 
 /**                                            macros/KEYS__ALT_GR/description
  * Define the functions for a "AltGr" key (i.e. a key that sends a "AltGr"
- * along with the keycode)
- *
- * Needed by ".../lib/layout/keys.h"
+ * along with the keycode).
  */
 #define  KEYS__ALT_GR(name, value)                             \
     void P(name) (void) { KF(press)(KEYBOARD__RightAlt);       \
@@ -60,6 +70,12 @@
     void R(name) (void) { KF(release)(value);                  \
                           KF(release)(KEYBOARD__RightAlt); }
 
+/**                                            macros/TYPE__ALT_GR/description
+ * Define the functions for a "AltGr" key (i.e. a key that sends a "AltGr"
+ * along with the keycode). Other than KEYS_SHIFTED, this does send
+ * a press and release event on key press and does not wait for the user
+ * releasing the key.
+ */
 #define  TYPE__ALT_GR(name, value)                             \
     void P(name) (void) { KF(press)(KEYBOARD__RightAlt);       \
                           usb__kb__send_report();              \
@@ -69,10 +85,8 @@
                           KF(release)(KEYBOARD__RightAlt); }   \
     void R(name) (void) { }
 
-/**                                            macros/KEYS__NON_DEAD/description
+/**                                            macros/TYPE__NON_DEAD/description
  * Define the functions for a normally dead key, to be non-dead.
- *
- * Needed by ".../lib/layout/keys.h"
  */
 #define  TYPE__NON_DEAD(name, value)                           \
     void P(name) (void) { KF(press)(value);                    \
@@ -84,10 +98,9 @@
                           KF(release)(KEYBOARD__Spacebar); }   \
     void R(name) (void) {}
 
-/**                                            macros/KEYS__NON_DEAD_SHIFTED/description
- * Define the functions for a normally dead key, to be non-dead.
- *
- * Needed by ".../lib/layout/keys.h"
+/**                                            macros/TYPE__NON_DEAD_SHIFTED/description
+ * Define the functions for a normally dead key, which needs the "shift"
+ * key to be pressed, to be non-dead.
  */
 #define  TYPE__NON_DEAD_SHIFTED(name, value)                   \
     void P(name) (void) { KF(press)(KEYBOARD__LeftShift);      \
@@ -102,10 +115,9 @@
                           KF(release)(KEYBOARD__Spacebar); }   \
     void R(name) (void) {}
 
-/**                                            macros/KEYS__NON_DEAD_ALT_GR/description
- * Define the functions for a normally dead key, to be non-dead.
- *
- * Needed by ".../lib/layout/keys.h"
+/**                                            macros/TYPE__NON_DEAD_ALT_GR/description
+ * Define the functions for a normally dead key, which needs the "AltGr"
+ * key, to be non-dead.
  */
 #define  TYPE__NON_DEAD_ALT_GR(name, value)                    \
     void P(name) (void) { KF(press)(KEYBOARD__RightAlt);       \

--- a/firmware/keyboard/ergodox/layout/fragments/keys.part.h
+++ b/firmware/keyboard/ergodox/layout/fragments/keys.part.h
@@ -33,6 +33,18 @@
     void R(name) (void) { KF(release)(value);                   \
                           KF(release)(KEYBOARD__LeftShift); }
 
+/**                                            macros/KEYS__ALT_GR/description
+ * Define the functions for a "AltGr" key (i.e. a key that sends a "AltGr"
+ * along with the keycode)
+ *
+ * Needed by ".../lib/layout/keys.h"
+ */
+#define  KEYS__ALT_GR(name, value)                             \
+    void P(name) (void) { KF(press)(KEYBOARD__RightAlt);       \
+                          KF(press)(value); }                  \
+    void R(name) (void) { KF(release)(value);                  \
+                          KF(release)(KEYBOARD__RightAlt); }
+
 /**                                    macros/KEYS__LAYER__PUSH_POP/description
  * Define the functions for a layer push-pop key (i.e. a layer shift key).
  *

--- a/firmware/keyboard/ergodox/layout/fragments/keys.part.h
+++ b/firmware/keyboard/ergodox/layout/fragments/keys.part.h
@@ -21,6 +21,12 @@
     void P(name) (void) { KF(press)(value); }   \
     void R(name) (void) { KF(release)(value); }
 
+#define  TYPE__DEFAULT(name, value)                   \
+    void P(name) (void) { KF(press)(value);           \
+                          usb__kb__send_report();     \
+                          KF(release)(value); }       \
+    void R(name) (void) { }
+
 /**                                            macros/KEYS__SHIFTED/description
  * Define the functions for a "shifted" key (i.e. a key that sends a "shift"
  * along with the keycode)
@@ -32,6 +38,15 @@
                           KF(press)(value); }                   \
     void R(name) (void) { KF(release)(value);                   \
                           KF(release)(KEYBOARD__LeftShift); }
+
+#define  TYPE__SHIFTED(name, value)                             \
+    void P(name) (void) { KF(press)(KEYBOARD__LeftShift);       \
+                          usb__kb__send_report();               \
+                          KF(press)(value);                     \
+                          usb__kb__send_report();               \
+                          KF(release)(value);                   \
+                          KF(release)(KEYBOARD__LeftShift); }   \
+    void R(name) (void) { }
 
 /**                                            macros/KEYS__ALT_GR/description
  * Define the functions for a "AltGr" key (i.e. a key that sends a "AltGr"
@@ -45,12 +60,21 @@
     void R(name) (void) { KF(release)(value);                  \
                           KF(release)(KEYBOARD__RightAlt); }
 
+#define  TYPE__ALT_GR(name, value)                             \
+    void P(name) (void) { KF(press)(KEYBOARD__RightAlt);       \
+                          usb__kb__send_report();              \
+                          KF(press)(value);                    \
+                          usb__kb__send_report();              \
+                          KF(release)(value);                  \
+                          KF(release)(KEYBOARD__RightAlt); }   \
+    void R(name) (void) { }
+
 /**                                            macros/KEYS__NON_DEAD/description
  * Define the functions for a normally dead key, to be non-dead.
  *
  * Needed by ".../lib/layout/keys.h"
  */
-#define  KEYS__NON_DEAD(name, value)                           \
+#define  TYPE__NON_DEAD(name, value)                           \
     void P(name) (void) { KF(press)(value);                    \
                           usb__kb__send_report();              \
                           KF(release)(value);                  \
@@ -65,8 +89,9 @@
  *
  * Needed by ".../lib/layout/keys.h"
  */
-#define  KEYS__NON_DEAD_SHIFTED(name, value)                   \
+#define  TYPE__NON_DEAD_SHIFTED(name, value)                   \
     void P(name) (void) { KF(press)(KEYBOARD__LeftShift);      \
+                          usb__kb__send_report();              \
                           KF(press)(value);                    \
                           usb__kb__send_report();              \
                           KF(release)(value);                  \
@@ -82,8 +107,9 @@
  *
  * Needed by ".../lib/layout/keys.h"
  */
-#define  KEYS__NON_DEAD_ALT_GR(name, value)                    \
+#define  TYPE__NON_DEAD_ALT_GR(name, value)                    \
     void P(name) (void) { KF(press)(KEYBOARD__RightAlt);       \
+                          usb__kb__send_report();              \
                           KF(press)(value);                    \
                           usb__kb__send_report();              \
                           KF(release)(value);                  \

--- a/firmware/keyboard/ergodox/layout/fragments/keys.part.h
+++ b/firmware/keyboard/ergodox/layout/fragments/keys.part.h
@@ -45,6 +45,49 @@
     void R(name) (void) { KF(release)(value);                  \
                           KF(release)(KEYBOARD__RightAlt); }
 
+/**                                            macros/KEYS__NON_DEAD/description
+ * Define the functions for a normally dead key, to be non-dead.
+ *
+ * Needed by ".../lib/layout/keys.h"
+ */
+#define  KEYS__NON_DEAD(name, value)                           \
+    void P(name) (void) { KF(press)(value); }                  \
+    void R(name) (void) { KF(release)(value);                  \
+                          usb__kb__send_report();              \
+                          KF(press)(value);                    \
+                          usb__kb__send_report();              \
+                          KF(release)(value); }
+
+/**                                            macros/KEYS__NON_DEAD_SHIFTED/description
+ * Define the functions for a normally dead key, to be non-dead.
+ *
+ * Needed by ".../lib/layout/keys.h"
+ */
+#define  KEYS__NON_DEAD_SHIFTED(name, value)                   \
+    void P(name) (void) { KF(press)(KEYBOARD__LeftShift);      \
+                          KF(press)(value); }                  \
+    void R(name) (void) { KF(release)(value);                  \
+                          usb__kb__send_report();              \
+                          KF(press)(value);                    \
+                          usb__kb__send_report();              \
+                          KF(release)(value);                  \
+                          KF(release)(KEYBOARD__LeftShift); }
+
+/**                                            macros/KEYS__NON_DEAD_ALT_GR/description
+ * Define the functions for a normally dead key, to be non-dead.
+ *
+ * Needed by ".../lib/layout/keys.h"
+ */
+#define  KEYS__NON_DEAD_ALT_GR(name, value)                    \
+    void P(name) (void) { KF(press)(KEYBOARD__RightAlt);       \
+                          KF(press)(value); }                  \
+    void R(name) (void) { KF(release)(value);                  \
+                          usb__kb__send_report();              \
+                          KF(press)(value);                    \
+                          usb__kb__send_report();              \
+                          KF(release)(value);                  \
+                          KF(release)(KEYBOARD__RightAlt); }
+
 /**                                    macros/KEYS__LAYER__PUSH_POP/description
  * Define the functions for a layer push-pop key (i.e. a layer shift key).
  *

--- a/firmware/keyboard/ergodox/layout/fragments/keys.part.h
+++ b/firmware/keyboard/ergodox/layout/fragments/keys.part.h
@@ -51,12 +51,12 @@
  * Needed by ".../lib/layout/keys.h"
  */
 #define  KEYS__NON_DEAD(name, value)                           \
-    void P(name) (void) { KF(press)(value); }                  \
-    void R(name) (void) { KF(release)(value);                  \
+    void P(name) (void) { KF(press)(value);                    \
+                          KF(press)(KEYBOARD__Spacebar);       \
                           usb__kb__send_report();              \
-                          KF(press)(value);                    \
-                          usb__kb__send_report();              \
-                          KF(release)(value); }
+                          KF(release)(value);                  \
+                          KF(release)(KEYBOARD__Spacebar); }   \
+    void R(name) (void) {}
 
 /**                                            macros/KEYS__NON_DEAD_SHIFTED/description
  * Define the functions for a normally dead key, to be non-dead.
@@ -65,13 +65,13 @@
  */
 #define  KEYS__NON_DEAD_SHIFTED(name, value)                   \
     void P(name) (void) { KF(press)(KEYBOARD__LeftShift);      \
-                          KF(press)(value); }                  \
-    void R(name) (void) { KF(release)(value);                  \
-                          usb__kb__send_report();              \
                           KF(press)(value);                    \
+                          KF(press)(KEYBOARD__Spacebar);       \
                           usb__kb__send_report();              \
                           KF(release)(value);                  \
-                          KF(release)(KEYBOARD__LeftShift); }
+                          KF(release)(KEYBOARD__Spacebar);     \
+                          KF(release)(KEYBOARD__LeftShift); }  \
+    void R(name) (void) {}
 
 /**                                            macros/KEYS__NON_DEAD_ALT_GR/description
  * Define the functions for a normally dead key, to be non-dead.
@@ -80,13 +80,13 @@
  */
 #define  KEYS__NON_DEAD_ALT_GR(name, value)                    \
     void P(name) (void) { KF(press)(KEYBOARD__RightAlt);       \
-                          KF(press)(value); }                  \
-    void R(name) (void) { KF(release)(value);                  \
-                          usb__kb__send_report();              \
                           KF(press)(value);                    \
+                          KF(press)(KEYBOARD__Spacebar);       \
                           usb__kb__send_report();              \
                           KF(release)(value);                  \
-                          KF(release)(KEYBOARD__RightAlt); }
+                          KF(release)(KEYBOARD__Spacebar);     \
+                          KF(release)(KEYBOARD__RightAlt); }   \
+    void R(name) (void) {}
 
 /**                                    macros/KEYS__LAYER__PUSH_POP/description
  * Define the functions for a layer push-pop key (i.e. a layer shift key).

--- a/firmware/keyboard/ergodox/layout/fragments/keys.part.h
+++ b/firmware/keyboard/ergodox/layout/fragments/keys.part.h
@@ -52,9 +52,11 @@
  */
 #define  KEYS__NON_DEAD(name, value)                           \
     void P(name) (void) { KF(press)(value);                    \
-                          KF(press)(KEYBOARD__Spacebar);       \
                           usb__kb__send_report();              \
                           KF(release)(value);                  \
+                          usb__kb__send_report();              \
+                          KF(press)(KEYBOARD__Spacebar);       \
+                          usb__kb__send_report();              \
                           KF(release)(KEYBOARD__Spacebar); }   \
     void R(name) (void) {}
 
@@ -66,11 +68,13 @@
 #define  KEYS__NON_DEAD_SHIFTED(name, value)                   \
     void P(name) (void) { KF(press)(KEYBOARD__LeftShift);      \
                           KF(press)(value);                    \
-                          KF(press)(KEYBOARD__Spacebar);       \
                           usb__kb__send_report();              \
                           KF(release)(value);                  \
-                          KF(release)(KEYBOARD__Spacebar);     \
-                          KF(release)(KEYBOARD__LeftShift); }  \
+                          KF(release)(KEYBOARD__LeftShift);    \
+                          usb__kb__send_report();              \
+                          KF(press)(KEYBOARD__Spacebar);       \
+                          usb__kb__send_report();              \
+                          KF(release)(KEYBOARD__Spacebar); }   \
     void R(name) (void) {}
 
 /**                                            macros/KEYS__NON_DEAD_ALT_GR/description
@@ -81,11 +85,13 @@
 #define  KEYS__NON_DEAD_ALT_GR(name, value)                    \
     void P(name) (void) { KF(press)(KEYBOARD__RightAlt);       \
                           KF(press)(value);                    \
-                          KF(press)(KEYBOARD__Spacebar);       \
                           usb__kb__send_report();              \
                           KF(release)(value);                  \
-                          KF(release)(KEYBOARD__Spacebar);     \
-                          KF(release)(KEYBOARD__RightAlt); }   \
+                          KF(release)(KEYBOARD__RightAlt);     \
+                          usb__kb__send_report();              \
+                          KF(press)(KEYBOARD__Spacebar);       \
+                          usb__kb__send_report();              \
+                          KF(release)(KEYBOARD__Spacebar); }   \
     void R(name) (void) {}
 
 /**                                    macros/KEYS__LAYER__PUSH_POP/description


### PR DESCRIPTION
These are my first additions to allow defining keys for entering chars, that are normally only accessible by pressing AltGr(the right alt) and some key when the os keyboard layout is set to some european layouts.

Additionally I added some macros to enter otherwise dead keys directly. If I want to enter for example ~, I need to press AltGr and + twice.
