### PR TITLE
Added layer "toggle" feature, so people don't have to simulate it anymore.

### DIFF
--- a/src/keyboard/ergodox/layout/workman-p-kinesis-mod.c
+++ b/src/keyboard/ergodox/layout/workman-p-kinesis-mod.c
@@ -233,7 +233,7 @@ KB_MATRIX_LAYER(
   // left thumb
   /* no key*/    0,            0,
   0 /*no key*/,  0 /*no key*/, 0,
-  MEDIAKEY_STOP, 0,            0,
+  MEDIAKEY_STOP, KEY_Insert,   0,
 
   // right hand
   KEY_F12,   KEY_F6,    KEY_F7,                KEY_F8,                  KEY_F9,              KEY_F10, KEY_ScrollLock,
@@ -498,7 +498,7 @@ KB_MATRIX_LAYER(
   // left thumb
   /*no key*/       ktrans,          ktrans,
   NULL /*no key*/, NULL /*no key*/, ktrans,
-  mprrel,          ktrans,          ktrans,
+  mprrel,          kprrel,          ktrans,
 
   // right hand
   kprrel,    kprrel,    kprrel, kprrel, kprrel, kprrel, kprrel,
@@ -763,7 +763,7 @@ KB_MATRIX_LAYER(
   // left thumb
   /*no key*/       ktrans,          ktrans,
   NULL /*no key*/, NULL /*no key*/, ktrans,
-  mprrel,          ktrans,          ktrans,
+  mprrel,          kprrel,          ktrans,
 
   // right hand
   kprrel,    kprrel,    kprrel, kprrel, kprrel, kprrel, kprrel,

--- a/src/keyboard/ergodox/layout/workman-p-kinesis-mod.c
+++ b/src/keyboard/ergodox/layout/workman-p-kinesis-mod.c
@@ -163,6 +163,16 @@ void kbfun_fix_shifted_press_release(void) {
 #define  lpop8    &kbfun_layer_pop_8
 #define  lpop9    &kbfun_layer_pop_9
 #define  lpop10   &kbfun_layer_pop_10
+#define  ltog1    &kbfun_layer_toggle_1
+#define  ltog2    &kbfun_layer_toggle_2
+#define  ltog3    &kbfun_layer_toggle_3
+#define  ltog4    &kbfun_layer_toggle_4
+#define  ltog5    &kbfun_layer_toggle_5
+#define  ltog6    &kbfun_layer_toggle_6
+#define  ltog7    &kbfun_layer_toggle_7
+#define  ltog8    &kbfun_layer_toggle_8
+#define  ltog9    &kbfun_layer_toggle_9
+#define  ltog10   &kbfun_layer_toggle_10
 // device
 #define  dbtldr   &kbfun_jump_to_bootloader
 
@@ -189,260 +199,260 @@ KB_MATRIX_LAYER(
   // unused
   0 /*no key*/,
   // left hand
-  KEY_Equal_Plus, KEY_1_Exclamation,     KEY_2_At,           KEY_3_Pound,   KEY_4_Dollar,   KEY_5_Percent, KEY_Application,  
-  KEY_Tab,        KEY_q_Q,               KEY_d_D,            KEY_r_R,       KEY_w_W,        KEY_b_B,       1,  
+  KEY_Equal_Plus, KEY_1_Exclamation,     KEY_2_At,           KEY_3_Pound,   KEY_4_Dollar,   KEY_5_Percent, KEY_Application,
+  KEY_Tab,        KEY_q_Q,               KEY_d_D,            KEY_r_R,       KEY_w_W,        KEY_b_B,       1,
   KEY_Escape,     KEY_a_A,               KEY_s_S,            KEY_h_H,       KEY_t_T,        KEY_g_G,       /*no key*/
-  KEY_LeftShift,  KEY_z_Z,               KEY_x_X,            KEY_m_M,       KEY_c_C,        KEY_v_V,       KEY_LeftAlt,  
+  KEY_LeftShift,  KEY_z_Z,               KEY_x_X,            KEY_m_M,       KEY_c_C,        KEY_v_V,       KEY_LeftAlt,
   KEY_LeftGUI,    KEY_GraveAccent_Tilde, KEY_Backslash_Pipe, KEY_LeftArrow, KEY_RightArrow, /*no key*/    /*no key*/
-  // left thumb                                                                                                                        
-  /*no key*/           KEY_LeftControl,   KEY_PrintScreen,  
-  0 /*no key*/,        0 /*no key*/,      KEY_Home,  
-  KEY_DeleteBackspace, KEY_DeleteForward, KEY_End,  
+  // left thumb
+  /*no key*/           KEY_LeftControl,   KEY_PrintScreen,
+  0 /*no key*/,        0 /*no key*/,      KEY_Home,
+  KEY_DeleteBackspace, KEY_DeleteForward, KEY_End,
 
   // right hand
   2,            KEY_6_Caret, KEY_7_Ampersand, KEY_8_Asterisk,     KEY_9_LeftParenthesis,     KEY_0_RightParenthesis,      KEY_Dash_Underscore,
-  1,            KEY_j_J,     KEY_f_F,         KEY_u_U,            KEY_p_P,                   KEY_Semicolon_Colon,         KEY_Backslash_Pipe,  
-  /*no key*/    KEY_y_Y,     KEY_n_N,         KEY_e_E,            KEY_o_O,                   KEY_i_I,                     KEY_SingleQuote_DoubleQuote,  
-  KEY_RightAlt, KEY_k_K,     KEY_l_L,         KEY_Comma_LessThan, KEY_Period_GreaterThan,    KEY_Slash_Question,          KEY_RightShift,  
-  /*no key*/    /*no key*/   KEY_UpArrow,     KEY_DownArrow,      KEY_LeftBracket_LeftBrace, KEY_RightBracket_RightBrace, KEY_RightGUI,  
+  1,            KEY_j_J,     KEY_f_F,         KEY_u_U,            KEY_p_P,                   KEY_Semicolon_Colon,         KEY_Backslash_Pipe,
+  /*no key*/    KEY_y_Y,     KEY_n_N,         KEY_e_E,            KEY_o_O,                   KEY_i_I,                     KEY_SingleQuote_DoubleQuote,
+  KEY_RightAlt, KEY_k_K,     KEY_l_L,         KEY_Comma_LessThan, KEY_Period_GreaterThan,    KEY_Slash_Question,          KEY_RightShift,
+  /*no key*/    /*no key*/   KEY_UpArrow,     KEY_DownArrow,      KEY_LeftBracket_LeftBrace, KEY_RightBracket_RightBrace, KEY_RightGUI,
   // right thumb
-  KEY_Pause,    KEY_RightControl, /*no key*/ 
+  KEY_Pause,    KEY_RightControl, /*no key*/
   KEY_PageUp,   0 /*no key*/,     0 /*no key*/,
-  KEY_PageDown, KEY_ReturnEnter,  KEY_Spacebar  
+  KEY_PageDown, KEY_ReturnEnter,  KEY_Spacebar
 ),
 // LAYER 1
 KB_MATRIX_LAYER(
   // unused
-  0 /*no key*/,  
+  0 /*no key*/,
   // left hand
-  KEY_CapsLock,  KEY_F1, KEY_F2, KEY_F3,              KEY_F4,              KEY_F5,    KEY_F11,  
-  0,             0,      0,      0,                   0,                   0,         0,  
+  KEY_CapsLock,  KEY_F1, KEY_F2, KEY_F3,              KEY_F4,              KEY_F5,    KEY_F11,
+  0,             0,      0,      0,                   0,                   0,         0,
   0,             0,      0,      0,                   0,                   0,         /*no key*/
-  0,             0,      0,      0,                   0,                   0,         0,  
-  0,             0,      0,      MEDIAKEY_PREV_TRACK, MEDIAKEY_NEXT_TRACK, /*no key*/ /*no key*/ 
+  0,             0,      0,      0,                   0,                   0,         0,
+  0,             0,      0,      MEDIAKEY_PREV_TRACK, MEDIAKEY_NEXT_TRACK, /*no key*/ /*no key*/
   // left thumb
-  /* no key*/    0,            0,  
-  0 /*no key*/,  0 /*no key*/, 0,  
-  MEDIAKEY_STOP, 0,            0,  
+  /* no key*/    0,            0,
+  0 /*no key*/,  0 /*no key*/, 0,
+  MEDIAKEY_STOP, 0,            0,
 
   // right hand
-  KEY_F12,   KEY_F6,    KEY_F7,                KEY_F8,                  KEY_F9,              KEY_F10, KEY_ScrollLock,  
-  0,         0,         0,                     0,                       0,                   0,       0,  
-  /*no key*/ 0,         0,                     0,                       0,                   0,       0,  
-  0,         0,         0,                     0,                       0,                   0,       0,  
-  /*no key*/ /*no key*/ MEDIAKEY_AUDIO_VOL_UP, MEDIAKEY_AUDIO_VOL_DOWN, MEDIAKEY_AUDIO_MUTE, 0,       3,  
+  KEY_F12,   KEY_F6,    KEY_F7,                KEY_F8,                  KEY_F9,              KEY_F10, KEY_ScrollLock,
+  0,         0,         0,                     0,                       0,                   0,       0,
+  /*no key*/ 0,         0,                     0,                       0,                   0,       0,
+  0,         0,         0,                     0,                       0,                   0,       0,
+  /*no key*/ /*no key*/ MEDIAKEY_AUDIO_VOL_UP, MEDIAKEY_AUDIO_VOL_DOWN, MEDIAKEY_AUDIO_MUTE, 4,       3,
   // right thumb
-  0, 0,            /*no key*/ 
-  0, 0 /*no key*/, 0 /*no key*/,  
-  0, 0,            MEDIAKEY_PLAY_PAUSE 
+  0, 0,            /*no key*/
+  0, 0 /*no key*/, 0 /*no key*/,
+  0, 0,            MEDIAKEY_PLAY_PAUSE
 ),
 // LAYER 2
 KB_MATRIX_LAYER(
   // unused
   0 /*no key*/,
   // left hand
-  0, 0, 0,          0, 0, 0,         0,  
-  0, 0, 0,          0, 0, 0,         0,  
-  0, 0, 0,          0, 0, 0,         /*no key*/ 
-  0, 0, 0,          0, 0, 0,         0,  
-  0, 0, KEY_Insert, 0, 0, /*no key*/ /*no key*/ 
+  0, 0, 0,          0, 0, 0,         0,
+  0, 0, 0,          0, 0, 0,         0,
+  0, 0, 0,          0, 0, 0,         /*no key*/
+  0, 0, 0,          0, 0, 0,         0,
+  0, 0, KEY_Insert, 0, 0, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/    0,            0,  
-  0 /*no key*/, 0 /*no key*/, 0,  
-  0,            0,            0,  
+  /*no key*/    0,            0,
+  0 /*no key*/, 0 /*no key*/, 0,
+  0,            0,            0,
 
   // right hand
-  2,         0,         KEYPAD_NumLock_Clear, KEYPAD_Equal,       KEYPAD_Slash,         KEYPAD_Asterisk, 0,  
-  0,         0,         KEYPAD_7_Home,        KEYPAD_8_UpArrow,   KEYPAD_9_PageUp,      KEYPAD_Minus,    0,  
-  /*no key*/ 0,         KEYPAD_4_LeftArrow,   KEYPAD_5,           KEYPAD_6_RightArrow,  KEYPAD_Plus,     0,  
-  0,         0,         KEYPAD_1_End,         KEYPAD_2_DownArrow, KEYPAD_3_PageDown,    KEY_ReturnEnter, 0,  
-  /*no key*/ /*no key*/ 0,                    0,                  KEYPAD_Period_Delete, KEY_ReturnEnter, 0,  
+  0,         0,         KEYPAD_NumLock_Clear, KEYPAD_Equal,       KEYPAD_Slash,         KEYPAD_Asterisk, 0,
+  0,         0,         KEYPAD_7_Home,        KEYPAD_8_UpArrow,   KEYPAD_9_PageUp,      KEYPAD_Minus,    0,
+  /*no key*/ 0,         KEYPAD_4_LeftArrow,   KEYPAD_5,           KEYPAD_6_RightArrow,  KEYPAD_Plus,     0,
+  0,         0,         KEYPAD_1_End,         KEYPAD_2_DownArrow, KEYPAD_3_PageDown,    KEY_ReturnEnter, 0,
+  /*no key*/ /*no key*/ 0,                    0,                  KEYPAD_Period_Delete, KEY_ReturnEnter, 0,
   // right thumb
-  0, 0,            /*no key*/ 
-  0, 0 /*no key*/, 0 /*no key*/,  
-  0, 0,            KEYPAD_0_Insert  
+  0, 0,            /*no key*/
+  0, 0 /*no key*/, 0 /*no key*/,
+  0, 0,            KEYPAD_0_Insert
 ),
 // LAYER 3
 KB_MATRIX_LAYER(
   // unused
-  0 /*no key*/,  
+  0 /*no key*/,
   // left hand
-  0, 0,       0,       0,       0,       0,         0,  
-  0, KEY_q_Q, KEY_w_W, KEY_e_E, KEY_r_R, KEY_t_T,   0,  
-  0, KEY_a_A, KEY_s_S, KEY_d_D, KEY_f_F, KEY_g_G,   /*no key*/ 
-  0, KEY_z_Z, KEY_x_X, KEY_c_C, KEY_v_V, KEY_b_B,   0,  
+  0, 0,       0,       0,       0,       0,         0,
+  0, KEY_q_Q, KEY_w_W, KEY_e_E, KEY_r_R, KEY_t_T,   0,
+  0, KEY_a_A, KEY_s_S, KEY_d_D, KEY_f_F, KEY_g_G,   /*no key*/
+  0, KEY_z_Z, KEY_x_X, KEY_c_C, KEY_v_V, KEY_b_B,   0,
   0, 0,       0,       0,       0,       /*no key*/ /*no key*/
   // left thumb
-  /*no key*/    0,            0,  
-  0 /*no key*/, 0 /*no key*/, 0,  
-  0,            0,            0,  
+  /*no key*/    0,            0,
+  0 /*no key*/, 0 /*no key*/, 0,
+  0,            0,            0,
 
   // right hand
-  0,         0,         0,       0,       0,       0,                   0,  
-  0,         KEY_y_Y,   KEY_u_U, KEY_i_I, KEY_o_O, KEY_p_P,             0,  
-  /*no key*/ KEY_h_H,   KEY_j_J, KEY_k_K, KEY_l_L, KEY_Semicolon_Colon, 0,  
-  0,         KEY_n_N,   KEY_m_M, 0,       0,       0,                   0,  
-  /*no key*/ /*no key*/ 0,       0,       0,       0,                   0,  
+  0,         0,         0,       0,       0,       0,                   0,
+  0,         KEY_y_Y,   KEY_u_U, KEY_i_I, KEY_o_O, KEY_p_P,             0,
+  /*no key*/ KEY_h_H,   KEY_j_J, KEY_k_K, KEY_l_L, KEY_Semicolon_Colon, 0,
+  0,         KEY_n_N,   KEY_m_M, 0,       0,       0,                   0,
+  /*no key*/ /*no key*/ 0,       0,       0,       0,                   0,
   // right thumb
-  0, 0,            /*no key*/ 
-  0, 0 /*no key*/, 0 /*no key*/,  
-  0, 0,            0  
+  0, 0,            /*no key*/
+  0, 0 /*no key*/, 0 /*no key*/,
+  0, 0,            0
 ),
 // LAYER 4
 KB_MATRIX_LAYER(
   // unused
-  0 /*no key*/,  
+  0 /*no key*/,
   // left hand
-  0,  0,  0,  0,  0,  0,         0,  
-  0,  0,  0,  0,  0,  0,         0,  
+  0,  0,  0,  0,  0,  0,         0,
+  0,  0,  0,  0,  0,  0,         0,
   0,  0,  0,  0,  0,  0,         /*no key*/
-  0,  0,  0,  0,  0,  0,         0,  
+  0,  0,  0,  0,  0,  0,         0,
   0,  0,  0,  0,  0,  /*no key*/ /*no key*/
   // left thumb
-  /*no key*/    0,            0,  
-  0 /*no key*/, 0 /*no key*/, 0,  
-  0,            0,            0,  
+  /*no key*/    0,            0,
+  0 /*no key*/, 0 /*no key*/, 0,
+  KEY_Spacebar, 0,            0,
 
   // right hand
-  0,         0,         0, 0, 0, 0, 0,  
-  0,         0,         0, 0, 0, 0, 0,  
-  /*no key*/ 0,         0, 0, 0, 0, 0,  
-  0,         0,         0, 0, 0, 0, 0,  
-  /*no key*/ /*no key*/ 0, 0, 0, 0, 0,  
+  0,         0,         0, 0, 0, 0, 0,
+  0,         0,         0, 0, 0, 0, 0,
+  /*no key*/ 0,         0, 0, 0, 0, 0,
+  0,         0,         0, 0, 0, 0, 0,
+  /*no key*/ /*no key*/ 0, 0, 0, 0, 0,
   // right thumb
-  0, 0,            /*no key*/ 
-  0, 0 /*no key*/, 0 /*no key*/,  
-  0, 0,            0  
+  0, 0,            /*no key*/
+  0, 0 /*no key*/, 0 /*no key*/,
+  0, 0,            KEY_DeleteBackspace
 ),
 // LAYER 5
 KB_MATRIX_LAYER(
   // unused
-  0 /*no key*/,  
+  0 /*no key*/,
   // left hand
-  0,  0,  0,  0,  0,  0,         0,  
-  0,  0,  0,  0,  0,  0,         0,  
+  0,  0,  0,  0,  0,  0,         0,
+  0,  0,  0,  0,  0,  0,         0,
   0,  0,  0,  0,  0,  0,         /*no key*/
-  0,  0,  0,  0,  0,  0,         0,  
+  0,  0,  0,  0,  0,  0,         0,
   0,  0,  0,  0,  0,  /*no key*/ /*no key*/
   // left thumb
-  /*no key*/    0,            0,  
-  0 /*no key*/, 0 /*no key*/, 0,  
-  0,            0,            0,  
+  /*no key*/    0,            0,
+  0 /*no key*/, 0 /*no key*/, 0,
+  0,            0,            0,
 
   // right hand
-  0,         0,         0, 0, 0, 0, 0,  
-  0,         0,         0, 0, 0, 0, 0,  
-  /*no key*/ 0,         0, 0, 0, 0, 0,  
-  0,         0,         0, 0, 0, 0, 0,  
-  /*no key*/ /*no key*/ 0, 0, 0, 0, 0,  
+  0,         0,         0, 0, 0, 0, 0,
+  0,         0,         0, 0, 0, 0, 0,
+  /*no key*/ 0,         0, 0, 0, 0, 0,
+  0,         0,         0, 0, 0, 0, 0,
+  /*no key*/ /*no key*/ 0, 0, 0, 0, 0,
   // right thumb
-  0, 0,            /*no key*/ 
-  0, 0 /*no key*/, 0 /*no key*/,  
-  0, 0,            0  
+  0, 0,            /*no key*/
+  0, 0 /*no key*/, 0 /*no key*/,
+  0, 0,            0
 ),
 // LAYER 6
 KB_MATRIX_LAYER(
   // unused
-  0 /*no key*/,  
+  0 /*no key*/,
   // left hand
-  0,  0,  0,  0,  0,  0,         0,  
-  0,  0,  0,  0,  0,  0,         0,  
+  0,  0,  0,  0,  0,  0,         0,
+  0,  0,  0,  0,  0,  0,         0,
   0,  0,  0,  0,  0,  0,         /*no key*/
-  0,  0,  0,  0,  0,  0,         0,  
+  0,  0,  0,  0,  0,  0,         0,
   0,  0,  0,  0,  0,  /*no key*/ /*no key*/
   // left thumb
-  /*no key*/    0,            0,  
-  0 /*no key*/, 0 /*no key*/, 0,  
-  0,            0,            0,  
+  /*no key*/    0,            0,
+  0 /*no key*/, 0 /*no key*/, 0,
+  0,            0,            0,
 
   // right hand
-  0,         0,         0, 0, 0, 0, 0,  
-  0,         0,         0, 0, 0, 0, 0,  
-  /*no key*/ 0,         0, 0, 0, 0, 0,  
-  0,         0,         0, 0, 0, 0, 0,  
-  /*no key*/ /*no key*/ 0, 0, 0, 0, 0,  
+  0,         0,         0, 0, 0, 0, 0,
+  0,         0,         0, 0, 0, 0, 0,
+  /*no key*/ 0,         0, 0, 0, 0, 0,
+  0,         0,         0, 0, 0, 0, 0,
+  /*no key*/ /*no key*/ 0, 0, 0, 0, 0,
   // right thumb
-  0, 0,            /*no key*/ 
-  0, 0 /*no key*/, 0 /*no key*/,  
-  0, 0,            0  
+  0, 0,            /*no key*/
+  0, 0 /*no key*/, 0 /*no key*/,
+  0, 0,            0
 ),
 // LAYER 7
 KB_MATRIX_LAYER(
   // unused
-  0 /*no key*/,  
+  0 /*no key*/,
   // left hand
-  0,  0,  0,  0,  0,  0,         0,  
-  0,  0,  0,  0,  0,  0,         0,  
+  0,  0,  0,  0,  0,  0,         0,
+  0,  0,  0,  0,  0,  0,         0,
   0,  0,  0,  0,  0,  0,         /*no key*/
-  0,  0,  0,  0,  0,  0,         0,  
+  0,  0,  0,  0,  0,  0,         0,
   0,  0,  0,  0,  0,  /*no key*/ /*no key*/
   // left thumb
-  /*no key*/    0,            0,  
-  0 /*no key*/, 0 /*no key*/, 0,  
-  0,            0,            0,  
+  /*no key*/    0,            0,
+  0 /*no key*/, 0 /*no key*/, 0,
+  0,            0,            0,
 
   // right hand
-  0,         0,         0, 0, 0, 0, 0,  
-  0,         0,         0, 0, 0, 0, 0,  
-  /*no key*/ 0,         0, 0, 0, 0, 0,  
-  0,         0,         0, 0, 0, 0, 0,  
-  /*no key*/ /*no key*/ 0, 0, 0, 0, 0,  
+  0,         0,         0, 0, 0, 0, 0,
+  0,         0,         0, 0, 0, 0, 0,
+  /*no key*/ 0,         0, 0, 0, 0, 0,
+  0,         0,         0, 0, 0, 0, 0,
+  /*no key*/ /*no key*/ 0, 0, 0, 0, 0,
   // right thumb
-  0, 0,            /*no key*/ 
-  0, 0 /*no key*/, 0 /*no key*/,  
-  0, 0,            0  
+  0, 0,            /*no key*/
+  0, 0 /*no key*/, 0 /*no key*/,
+  0, 0,            0
 ),
 // LAYER 8
 KB_MATRIX_LAYER(
   // unused
-  0 /*no key*/,  
+  0 /*no key*/,
   // left hand
-  0,  0,  0,  0,  0,  0,         0,  
-  0,  0,  0,  0,  0,  0,         0,  
+  0,  0,  0,  0,  0,  0,         0,
+  0,  0,  0,  0,  0,  0,         0,
   0,  0,  0,  0,  0,  0,         /*no key*/
-  0,  0,  0,  0,  0,  0,         0,  
+  0,  0,  0,  0,  0,  0,         0,
   0,  0,  0,  0,  0,  /*no key*/ /*no key*/
   // left thumb
-  /*no key*/    0,            0,  
-  0 /*no key*/, 0 /*no key*/, 0,  
-  0,            0,            0,  
+  /*no key*/    0,            0,
+  0 /*no key*/, 0 /*no key*/, 0,
+  0,            0,            0,
 
   // right hand
-  0,         0,         0, 0, 0, 0, 0,  
-  0,         0,         0, 0, 0, 0, 0,  
-  /*no key*/ 0,         0, 0, 0, 0, 0,  
-  0,         0,         0, 0, 0, 0, 0,  
-  /*no key*/ /*no key*/ 0, 0, 0, 0, 0,  
+  0,         0,         0, 0, 0, 0, 0,
+  0,         0,         0, 0, 0, 0, 0,
+  /*no key*/ 0,         0, 0, 0, 0, 0,
+  0,         0,         0, 0, 0, 0, 0,
+  /*no key*/ /*no key*/ 0, 0, 0, 0, 0,
   // right thumb
-  0, 0,            /*no key*/ 
-  0, 0 /*no key*/, 0 /*no key*/,  
-  0, 0,            0  
+  0, 0,            /*no key*/
+  0, 0 /*no key*/, 0 /*no key*/,
+  0, 0,            0
 ),
 // LAYER 9
 KB_MATRIX_LAYER(
   // unused
-  0 /*no key*/,  
+  0 /*no key*/,
   // left hand
-  0,  0,  0,  0,  0,  0,         0,  
-  0,  0,  0,  0,  0,  0,         0,  
+  0,  0,  0,  0,  0,  0,         0,
+  0,  0,  0,  0,  0,  0,         0,
   0,  0,  0,  0,  0,  0,         /*no key*/
-  0,  0,  0,  0,  0,  0,         0,  
+  0,  0,  0,  0,  0,  0,         0,
   0,  0,  0,  0,  0,  /*no key*/ /*no key*/
   // left thumb
-  /*no key*/    0,            0,  
-  0 /*no key*/, 0 /*no key*/, 0,  
-  0,            0,            0,  
+  /*no key*/    0,            0,
+  0 /*no key*/, 0 /*no key*/, 0,
+  0,            0,            0,
 
   // right hand
-  0,         0,         0, 0, 0, 0, 0,  
-  0,         0,         0, 0, 0, 0, 0,  
-  /*no key*/ 0,         0, 0, 0, 0, 0,  
-  0,         0,         0, 0, 0, 0, 0,  
-  /*no key*/ /*no key*/ 0, 0, 0, 0, 0,  
+  0,         0,         0, 0, 0, 0, 0,
+  0,         0,         0, 0, 0, 0, 0,
+  /*no key*/ 0,         0, 0, 0, 0, 0,
+  0,         0,         0, 0, 0, 0, 0,
+  /*no key*/ /*no key*/ 0, 0, 0, 0, 0,
   // right thumb
-  0, 0,            /*no key*/ 
-  0, 0 /*no key*/, 0 /*no key*/,  
-  0, 0,            0  
+  0, 0,            /*no key*/
+  0, 0 /*no key*/, 0 /*no key*/,
+  0, 0,            0
 ),
 };
 // ----------------------------------------------------------------------------
@@ -452,262 +462,262 @@ const void_funptr_t PROGMEM _kb_layout_press[KB_LAYERS][KB_ROWS][KB_COLUMNS] = {
 // LAYER 0
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  kprrel, sinvert, sinvert, sinvert, sinvert, sinvert,   kprrel,  
-  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  kprrel,    lpush1,  
-  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  kprrel,    /*no key*/ 
-  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  kprrel,    kprrel,  
-  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  /*no key*/ /*no key*/ 
+  kprrel, sinvert, sinvert, sinvert, sinvert, sinvert,   kprrel,
+  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  kprrel,    lpush1,
+  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  kprrel,    /*no key*/
+  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  kprrel,    kprrel,
+  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       kprrel,          kprrel,  
-  NULL /*no key*/, NULL /*no key*/, kprrel,  
-  kprrel,          kprrel,          kprrel,  
+  /*no key*/       kprrel,          kprrel,
+  NULL /*no key*/, NULL /*no key*/, kprrel,
+  kprrel,          kprrel,          kprrel,
 
   // right hand
-  lpush2,    sinvert,   sinvert, sinvert, sinvert, sinvert, kprrel,  
-  lpush1,    kprrel,    kprrel,  kprrel,  kprrel,  kprrel,  kprrel,  
-  /*no key*/ kprrel,    kprrel,  kprrel,  kprrel,  kprrel,  kprrel,  
-  kprrel,    kprrel,    kprrel,  kprrel,  kprrel,  kprrel,  kprrel,  
-  /*no key*/ /*no key*/ kprrel,  kprrel,  kprrel,  kprrel,  kprrel,  
+  ltog2,     sinvert,   sinvert, sinvert, sinvert, sinvert, kprrel,
+  lpush1,    kprrel,    kprrel,  kprrel,  kprrel,  kprrel,  kprrel,
+  /*no key*/ kprrel,    kprrel,  kprrel,  kprrel,  kprrel,  kprrel,
+  kprrel,    kprrel,    kprrel,  kprrel,  kprrel,  kprrel,  kprrel,
+  /*no key*/ /*no key*/ kprrel,  kprrel,  kprrel,  kprrel,  kprrel,
   // right thumb
-  kprrel, kprrel,          /*no key*/ 
-  kprrel, NULL /*no key*/, NULL /*no key*/,  
-  kprrel, kprrel,          kprrel  
+  kprrel, kprrel,          /*no key*/
+  kprrel, NULL /*no key*/, NULL /*no key*/,
+  kprrel, kprrel,          kprrel
 ),
 // LAYER 1
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  kprrel, kprrel, kprrel, kprrel, kprrel, kprrel,    kprrel,  
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,  
+  kprrel, kprrel, kprrel, kprrel, kprrel, kprrel,    kprrel,
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
   ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    /*no key*/
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,  
-  lpop,   ktrans, ktrans, mprrel, mprrel, /*no key*/ /*no key*/ 
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  lpop,   ktrans, ktrans, mprrel, mprrel, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       ktrans,          ktrans,  
-  NULL /*no key*/, NULL /*no key*/, ktrans,  
-  mprrel,          ktrans,          ktrans,  
+  /*no key*/       ktrans,          ktrans,
+  NULL /*no key*/, NULL /*no key*/, ktrans,
+  mprrel,          ktrans,          ktrans,
 
   // right hand
-  kprrel,    kprrel,    kprrel, kprrel, kprrel, kprrel, kprrel,  
-  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,  
-  /*no key*/ ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,  
-  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,  
-  /*no key*/ /*no key*/ mprrel, mprrel, mprrel, ktrans, lpush3,  
+  kprrel,    kprrel,    kprrel, kprrel, kprrel, kprrel, kprrel,
+  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  /*no key*/ ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  /*no key*/ /*no key*/ mprrel, mprrel, mprrel, ltog4,  ltog3,
   // right thumb
-  ktrans, ktrans,          /*no key*/ 
-  ktrans, NULL /*no key*/, NULL /*no key*/,  
-  ktrans, ktrans,          mprrel  
+  ktrans, ktrans,          /*no key*/
+  ktrans, NULL /*no key*/, NULL /*no key*/,
+  ktrans, ktrans,          mprrel
 ),
 // LAYER 2
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,  
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,  
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
   ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    /*no key*/
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,  
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
   ktrans, ktrans, kprrel, ktrans, ktrans, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       ktrans,          ktrans,  
-  NULL /*no key*/, NULL /*no key*/, ktrans,  
-  ktrans,          ktrans,          ktrans,  
+  /*no key*/       ktrans,          ktrans,
+  NULL /*no key*/, NULL /*no key*/, ktrans,
+  ktrans,          ktrans,          ktrans,
 
   // right hand
-  lpop2,     ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,  
-  ktrans,    ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,  
-  /*no key*/ ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans, 
-  ktrans,    ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,  
-  /*no key*/ /*no key*/ ktrans, ktrans, kprrel, kprrel, ktrans,  
+  ktrans,    ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,
+  ktrans,    ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,
+  /*no key*/ ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,
+  ktrans,    ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,
+  /*no key*/ /*no key*/ ktrans, ktrans, kprrel, kprrel, ktrans,
   // right thumb
-  ktrans, ktrans,          /*no key*/ 
-  ktrans, NULL /*no key*/, NULL /*no key*/,  
-  ktrans, ktrans,          kprrel  
+  ktrans, ktrans,          /*no key*/
+  ktrans, NULL /*no key*/, NULL /*no key*/,
+  ktrans, ktrans,          kprrel
 ),
 // LAYER 3
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,  
-  ktrans, kprrel, kprrel, kprrel, kprrel, kprrel,    ktrans,  
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  ktrans, kprrel, kprrel, kprrel, kprrel, kprrel,    ktrans,
   ktrans, kprrel, kprrel, kprrel, kprrel, kprrel,    /*no key*/
-  ktrans, kprrel, kprrel, kprrel, kprrel, kprrel,    ktrans,  
+  ktrans, kprrel, kprrel, kprrel, kprrel, kprrel,    ktrans,
   ktrans, ktrans, ktrans, ktrans, ktrans, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       ktrans,          ktrans,  
-  NULL /*no key*/, NULL /*no key*/, ktrans,  
-  ktrans,          ktrans,          ktrans,  
+  /*no key*/       ktrans,          ktrans,
+  NULL /*no key*/, NULL /*no key*/, ktrans,
+  ktrans,          ktrans,          ktrans,
 
   // right hand
-  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,  
-  ktrans,    kprrel,    kprrel, kprrel, kprrel, kprrel, ktrans,  
-  /*no key*/ kprrel,    kprrel, kprrel, kprrel, kprrel, ktrans,  
-  ktrans,    kprrel,    kprrel, ktrans, ktrans, ktrans, ktrans,  
-  /*no key*/ /*no key*/ ktrans, ktrans, ktrans, ktrans, ktrans,  
+  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  ktrans,    kprrel,    kprrel, kprrel, kprrel, kprrel, ktrans,
+  /*no key*/ kprrel,    kprrel, kprrel, kprrel, kprrel, ktrans,
+  ktrans,    kprrel,    kprrel, ktrans, ktrans, ktrans, ktrans,
+  /*no key*/ /*no key*/ ktrans, ktrans, ktrans, ktrans, ktrans,
   // right thumb
-  ktrans, ktrans,          /*no key*/ 
-  ktrans, NULL /*no key*/, NULL /*no key*/,  
-  ktrans, ktrans,          ktrans  
+  ktrans, ktrans,          /*no key*/
+  ktrans, NULL /*no key*/, NULL /*no key*/,
+  ktrans, ktrans,          ktrans
 ),
 // LAYER 4
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/ 
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    /*no key*/
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  ktrans, ktrans, ktrans, ktrans, ktrans, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       NULL,            NULL,  
-  NULL /*no key*/, NULL /*no key*/, NULL,  
-  NULL,            NULL,            NULL,  
+  /*no key*/       ktrans,          ktrans,
+  NULL /*no key*/, NULL /*no key*/, ktrans,
+  kprrel,          ktrans,          ktrans,
 
   // right hand
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,  
+  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  /*no key*/ ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  /*no key*/ /*no key*/ ktrans, ktrans, ktrans, ktrans, ktrans,
   // right thumb
-  NULL, NULL,            /*no key*/ 
-  NULL, NULL /*no key*/, NULL /*no key*/,  
-  NULL, NULL,            NULL  
+  ktrans, ktrans,          /*no key*/
+  ktrans, NULL /*no key*/, NULL /*no key*/,
+  ktrans, ktrans,          kprrel
 ),
 // LAYER 5
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/ 
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
   NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       NULL,            NULL,  
-  NULL /*no key*/, NULL /*no key*/, NULL,  
-  NULL,            NULL,            NULL,  
+  /*no key*/       NULL,            NULL,
+  NULL /*no key*/, NULL /*no key*/, NULL,
+  NULL,            NULL,            NULL,
 
   // right hand
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,  
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,
   // right thumb
-  NULL, NULL,            /*no key*/ 
-  NULL, NULL /*no key*/, NULL /*no key*/,  
-  NULL, NULL,            NULL  
+  NULL, NULL,            /*no key*/
+  NULL, NULL /*no key*/, NULL /*no key*/,
+  NULL, NULL,            NULL
 ),
 // LAYER 6
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/ 
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
   NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       NULL,            NULL,  
-  NULL /*no key*/, NULL /*no key*/, NULL,  
-  NULL,            NULL,            NULL,  
+  /*no key*/       NULL,            NULL,
+  NULL /*no key*/, NULL /*no key*/, NULL,
+  NULL,            NULL,            NULL,
 
   // right hand
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,  
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,
   // right thumb
-  NULL, NULL,            /*no key*/ 
-  NULL, NULL /*no key*/, NULL /*no key*/,  
-  NULL, NULL,            NULL  
+  NULL, NULL,            /*no key*/
+  NULL, NULL /*no key*/, NULL /*no key*/,
+  NULL, NULL,            NULL
 ),
 // LAYER 7
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/ 
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
   NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       NULL,            NULL,  
-  NULL /*no key*/, NULL /*no key*/, NULL,  
-  NULL,            NULL,            NULL,  
+  /*no key*/       NULL,            NULL,
+  NULL /*no key*/, NULL /*no key*/, NULL,
+  NULL,            NULL,            NULL,
 
   // right hand
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,  
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,
   // right thumb
-  NULL, NULL,            /*no key*/ 
-  NULL, NULL /*no key*/, NULL /*no key*/,  
-  NULL, NULL,            NULL  
+  NULL, NULL,            /*no key*/
+  NULL, NULL /*no key*/, NULL /*no key*/,
+  NULL, NULL,            NULL
 ),
 // LAYER 8
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/ 
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
   NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       NULL,            NULL,  
-  NULL /*no key*/, NULL /*no key*/, NULL,  
-  NULL,            NULL,            NULL,  
+  /*no key*/       NULL,            NULL,
+  NULL /*no key*/, NULL /*no key*/, NULL,
+  NULL,            NULL,            NULL,
 
   // right hand
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,  
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,
   // right thumb
-  NULL, NULL,            /*no key*/ 
-  NULL, NULL /*no key*/, NULL /*no key*/,  
-  NULL, NULL,            NULL  
+  NULL, NULL,            /*no key*/
+  NULL, NULL /*no key*/, NULL /*no key*/,
+  NULL, NULL,            NULL
 ),
 // LAYER 9
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/ 
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
   NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       NULL,            NULL,  
-  NULL /*no key*/, NULL /*no key*/, NULL,  
-  NULL,            NULL,            NULL,  
+  /*no key*/       NULL,            NULL,
+  NULL /*no key*/, NULL /*no key*/, NULL,
+  NULL,            NULL,            NULL,
 
   // right hand
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,  
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,
   // right thumb
-  NULL, NULL,            /*no key*/ 
-  NULL, NULL /*no key*/, NULL /*no key*/,  
-  NULL, NULL,            NULL  
+  NULL, NULL,            /*no key*/
+  NULL, NULL /*no key*/, NULL /*no key*/,
+  NULL, NULL,            NULL
 ),
 };
 // ----------------------------------------------------------------------------
@@ -717,262 +727,262 @@ const void_funptr_t PROGMEM _kb_layout_release[KB_LAYERS][KB_ROWS][KB_COLUMNS] =
 // LAYER 0
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  kprrel, sinvert, sinvert, sinvert, sinvert, sinvert,   kprrel,  
-  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  kprrel,    lpop1,  
-  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  kprrel,    /*no key*/ 
-  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  kprrel,    kprrel,  
+  kprrel, sinvert, sinvert, sinvert, sinvert, sinvert,   kprrel,
+  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  kprrel,    lpop1,
+  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  kprrel,    /*no key*/
+  kprrel, kprrel,  kprrel,  kprrel,  kprrel,  kprrel,    kprrel,
   kprrel, kprrel,  kprrel,  kprrel,  kprrel,  /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       kprrel,          kprrel,  
-  NULL /*no key*/, NULL /*no key*/, kprrel,  
-  kprrel,          kprrel,          kprrel,  
+  /*no key*/       kprrel,          kprrel,
+  NULL /*no key*/, NULL /*no key*/, kprrel,
+  kprrel,          kprrel,          kprrel,
 
   // right hand
-  NULL,      sinvert,   sinvert, sinvert, sinvert, sinvert, kprrel,  
-  lpop1,     kprrel,    kprrel,  kprrel,  kprrel,  kprrel,  kprrel,  
-  /*no key*/ kprrel,    kprrel,  kprrel,  kprrel,  kprrel,  kprrel,  
-  kprrel,    kprrel,    kprrel,  kprrel,  kprrel,  kprrel,  kprrel,  
-  /*no key*/ /*no key*/ kprrel,  kprrel,  kprrel,  kprrel,  kprrel,  
+  NULL,      sinvert,   sinvert, sinvert, sinvert, sinvert, kprrel,
+  lpop1,     kprrel,    kprrel,  kprrel,  kprrel,  kprrel,  kprrel,
+  /*no key*/ kprrel,    kprrel,  kprrel,  kprrel,  kprrel,  kprrel,
+  kprrel,    kprrel,    kprrel,  kprrel,  kprrel,  kprrel,  kprrel,
+  /*no key*/ /*no key*/ kprrel,  kprrel,  kprrel,  kprrel,  kprrel,
   // right thumb
-  kprrel, kprrel,          /*no key*/ 
-  kprrel, NULL /*no key*/, NULL /*no key*/,  
-  kprrel, kprrel,          kprrel  
+  kprrel, kprrel,          /*no key*/
+  kprrel, NULL /*no key*/, NULL /*no key*/,
+  kprrel, kprrel,          kprrel
 ),
 // LAYER 1
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  kprrel, kprrel, kprrel, kprrel, kprrel, kprrel,    kprrel,  
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,  
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    /*no key*/ 
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,  
-  NULL,   ktrans, ktrans, mprrel, mprrel, /*no key*/ /*no key*/ 
+  kprrel, kprrel, kprrel, kprrel, kprrel, kprrel,    kprrel,
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    /*no key*/
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  NULL,   ktrans, ktrans, mprrel, mprrel, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       ktrans,          ktrans,  
-  NULL /*no key*/, NULL /*no key*/, ktrans,  
-  mprrel,          ktrans,          ktrans,  
+  /*no key*/       ktrans,          ktrans,
+  NULL /*no key*/, NULL /*no key*/, ktrans,
+  mprrel,          ktrans,          ktrans,
 
   // right hand
-  kprrel,    kprrel,    kprrel, kprrel, kprrel, kprrel, kprrel,  
-  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,  
-  /*no key*/ ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,  
-  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,  
-  /*no key*/ /*no key*/ mprrel, mprrel, mprrel, ktrans, NULL,  
+  kprrel,    kprrel,    kprrel, kprrel, kprrel, kprrel, kprrel,
+  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  /*no key*/ ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  /*no key*/ /*no key*/ mprrel, mprrel, mprrel, NULL, NULL,
   // right thumb
-  ktrans, ktrans,          /*no key*/ 
-  ktrans, NULL /*no key*/, NULL /*no key*/,  
-  ktrans, ktrans,          mprrel  
+  ktrans, ktrans,          /*no key*/
+  ktrans, NULL /*no key*/, NULL /*no key*/,
+  ktrans, ktrans,          mprrel
 ),
 // LAYER 2
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,  
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,  
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    /*no key*/ 
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,  
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    /*no key*/
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
   ktrans, ktrans, kprrel, ktrans, ktrans, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       ktrans,          ktrans,  
-  NULL /*no key*/, NULL /*no key*/, ktrans,  
-  ktrans,          ktrans,          ktrans,  
+  /*no key*/       ktrans,          ktrans,
+  NULL /*no key*/, NULL /*no key*/, ktrans,
+  ktrans,          ktrans,          ktrans,
 
   // right hand
-  NULL,      ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,  
-  ktrans,    ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,  
-  /*no key*/ ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,  
-  ktrans,    ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,  
-  /*no key*/ /*no key*/ ktrans, ktrans, kprrel, kprrel, ktrans,  
+  ktrans,    ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,
+  ktrans,    ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,
+  /*no key*/ ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,
+  ktrans,    ktrans,    kprrel, kprrel, kprrel, kprrel, ktrans,
+  /*no key*/ /*no key*/ ktrans, ktrans, kprrel, kprrel, ktrans,
   // right thumb
-  ktrans, ktrans,          /*no key*/ 
-  ktrans, NULL /*no key*/, NULL /*no key*/,  
-  ktrans, ktrans,          kprrel  
+  ktrans, ktrans,          /*no key*/
+  ktrans, NULL /*no key*/, NULL /*no key*/,
+  ktrans, ktrans,          kprrel
 ),
 // LAYER 3
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,  
-  ktrans, kprrel, kprrel, kprrel, kprrel, kprrel,    ktrans,  
-  ktrans, kprrel, kprrel, kprrel, kprrel, kprrel,    /*no key*/ 
-  ktrans, kprrel, kprrel, kprrel, kprrel, kprrel,    ktrans,  
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  ktrans, kprrel, kprrel, kprrel, kprrel, kprrel,    ktrans,
+  ktrans, kprrel, kprrel, kprrel, kprrel, kprrel,    /*no key*/
+  ktrans, kprrel, kprrel, kprrel, kprrel, kprrel,    ktrans,
   ktrans, ktrans, ktrans, ktrans, ktrans, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       ktrans,          ktrans,  
-  NULL /*no key*/, NULL /*no key*/, ktrans,  
-  ktrans,          ktrans,          ktrans,  
+  /*no key*/       ktrans,          ktrans,
+  NULL /*no key*/, NULL /*no key*/, ktrans,
+  ktrans,          ktrans,          ktrans,
 
   // right hand
-  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,  
-  ktrans,    kprrel,    kprrel, kprrel, kprrel, kprrel, ktrans,  
-  /*no key*/ kprrel,    kprrel, kprrel, kprrel, kprrel, ktrans,  
-  ktrans,    kprrel,    kprrel, ktrans, ktrans, ktrans, ktrans,  
-  /*no key*/ /*no key*/ ktrans, ktrans, ktrans, ktrans, ktrans,  
+  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  ktrans,    kprrel,    kprrel, kprrel, kprrel, kprrel, ktrans,
+  /*no key*/ kprrel,    kprrel, kprrel, kprrel, kprrel, ktrans,
+  ktrans,    kprrel,    kprrel, ktrans, ktrans, ktrans, ktrans,
+  /*no key*/ /*no key*/ ktrans, ktrans, ktrans, ktrans, ktrans,
   // right thumb
-  ktrans, ktrans,          /*no key*/ 
-  ktrans, NULL /*no key*/, NULL /*no key*/,  
-  ktrans, ktrans,          ktrans  
+  ktrans, ktrans,          /*no key*/
+  ktrans, NULL /*no key*/, NULL /*no key*/,
+  ktrans, ktrans,          ktrans
 ),
 // LAYER 4
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/ 
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/ 
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    /*no key*/
+  ktrans, ktrans, ktrans, ktrans, ktrans, ktrans,    ktrans,
+  ktrans, ktrans, ktrans, ktrans, ktrans, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       NULL,            NULL,  
-  NULL /*no key*/, NULL /*no key*/, NULL,  
-  NULL,            NULL,            NULL,  
+  /*no key*/       ktrans,          ktrans,
+  NULL /*no key*/, NULL /*no key*/, ktrans,
+  kprrel,          ktrans,          ktrans,
 
   // right hand
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,  
+  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  /*no key*/ ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  ktrans,    ktrans,    ktrans, ktrans, ktrans, ktrans, ktrans,
+  /*no key*/ /*no key*/ ktrans, ktrans, ktrans, ktrans, ktrans,
   // right thumb
-  NULL, NULL,            /*no key*/ 
-  NULL, NULL /*no key*/, NULL /*no key*/,  
-  NULL, NULL,            NULL  
+  ktrans, ktrans,          /*no key*/
+  ktrans, NULL /*no key*/, NULL /*no key*/,
+  ktrans, ktrans,          kprrel
 ),
 // LAYER 5
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/ 
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/ 
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       NULL,            NULL,  
-  NULL /*no key*/, NULL /*no key*/, NULL,  
-  NULL,            NULL,            NULL,  
+  /*no key*/       NULL,            NULL,
+  NULL /*no key*/, NULL /*no key*/, NULL,
+  NULL,            NULL,            NULL,
 
   // right hand
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,  
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,
   // right thumb
-  NULL, NULL,            /*no key*/ 
-  NULL, NULL /*no key*/, NULL /*no key*/,  
-  NULL, NULL,            NULL  
+  NULL, NULL,            /*no key*/
+  NULL, NULL /*no key*/, NULL /*no key*/,
+  NULL, NULL,            NULL
 ),
 // LAYER 6
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/ 
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/ 
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       NULL,            NULL,  
-  NULL /*no key*/, NULL /*no key*/, NULL,  
-  NULL,            NULL,            NULL,  
+  /*no key*/       NULL,            NULL,
+  NULL /*no key*/, NULL /*no key*/, NULL,
+  NULL,            NULL,            NULL,
 
   // right hand
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,  
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,
   // right thumb
-  NULL, NULL,            /*no key*/ 
-  NULL, NULL /*no key*/, NULL /*no key*/,  
-  NULL, NULL,            NULL  
+  NULL, NULL,            /*no key*/
+  NULL, NULL /*no key*/, NULL /*no key*/,
+  NULL, NULL,            NULL
 ),
 // LAYER 7
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/ 
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/ 
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       NULL,            NULL,  
-  NULL /*no key*/, NULL /*no key*/, NULL,  
-  NULL,            NULL,            NULL,  
+  /*no key*/       NULL,            NULL,
+  NULL /*no key*/, NULL /*no key*/, NULL,
+  NULL,            NULL,            NULL,
 
   // right hand
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,  
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,
   // right thumb
-  NULL, NULL,            /*no key*/ 
-  NULL, NULL /*no key*/, NULL /*no key*/,  
-  NULL, NULL,            NULL  
+  NULL, NULL,            /*no key*/
+  NULL, NULL /*no key*/, NULL /*no key*/,
+  NULL, NULL,            NULL
 ),
 // LAYER 8
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/ 
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/ 
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       NULL,            NULL,  
-  NULL /*no key*/, NULL /*no key*/, NULL,  
-  NULL,            NULL,            NULL,  
+  /*no key*/       NULL,            NULL,
+  NULL /*no key*/, NULL /*no key*/, NULL,
+  NULL,            NULL,            NULL,
 
   // right hand
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,  
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,
   // right thumb
-  NULL, NULL,            /*no key*/ 
-  NULL, NULL /*no key*/, NULL /*no key*/,  
-  NULL, NULL,            NULL  
+  NULL, NULL,            /*no key*/
+  NULL, NULL /*no key*/, NULL /*no key*/,
+  NULL, NULL,            NULL
 ),
 // LAYER 9
 KB_MATRIX_LAYER(
   // unused
-  NULL /*no key*/,  
+  NULL /*no key*/,
   // left hand
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/ 
-  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,  
-  NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/ 
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, NULL,      /*no key*/
+  NULL, NULL, NULL, NULL, NULL, NULL,      NULL,
+  NULL, NULL, NULL, NULL, NULL, /*no key*/ /*no key*/
   // left thumb
-  /*no key*/       NULL,            NULL,  
-  NULL /*no key*/, NULL /*no key*/, NULL,  
-  NULL,            NULL,            NULL,  
+  /*no key*/       NULL,            NULL,
+  NULL /*no key*/, NULL /*no key*/, NULL,
+  NULL,            NULL,            NULL,
 
   // right hand
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,  
-  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,  
-  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,  
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ NULL,      NULL, NULL, NULL, NULL, NULL,
+  NULL,      NULL,      NULL, NULL, NULL, NULL, NULL,
+  /*no key*/ /*no key*/ NULL, NULL, NULL, NULL, NULL,
   // right thumb
-  NULL, NULL,            /*no key*/ 
-  NULL, NULL /*no key*/, NULL /*no key*/,  
-  NULL, NULL,            NULL  
+  NULL, NULL,            /*no key*/
+  NULL, NULL /*no key*/, NULL /*no key*/,
+  NULL, NULL,            NULL
 ),
 };
 // ----------------------------------------------------------------------------

--- a/src/lib/key-functions/public.h
+++ b/src/lib/key-functions/public.h
@@ -51,6 +51,16 @@
 	void kbfun_layer_pop_8   (void);
 	void kbfun_layer_pop_9   (void);
 	void kbfun_layer_pop_10  (void);
+	void kbfun_layer_toggle_1   (void);
+	void kbfun_layer_toggle_2   (void);
+	void kbfun_layer_toggle_3   (void);
+	void kbfun_layer_toggle_4   (void);
+	void kbfun_layer_toggle_5   (void);
+	void kbfun_layer_toggle_6   (void);
+	void kbfun_layer_toggle_7   (void);
+	void kbfun_layer_toggle_8   (void);
+	void kbfun_layer_toggle_9   (void);
+	void kbfun_layer_toggle_10  (void);
 	// ---
 
 	// device

--- a/src/lib/key-functions/public/basic.c
+++ b/src/lib/key-functions/public/basic.c
@@ -103,9 +103,17 @@ void kbfun_transparent(void) {
 //  layer 0 even if we will never have a push or pop function for it
 static uint8_t layer_ids[1 + MAX_LAYER_PUSH_POP_FUNCTIONS];
 
+static void layer_pop(uint8_t local_id) {
+  uint8_t id = layer_ids[local_id];
+  if (id != 0) {
+    main_layers_pop_id(id);
+	  layer_ids[local_id] = 0;
+  }
+}
+
 static void layer_push(uint8_t local_id) {
 	uint8_t keycode = kb_layout_get(LAYER, ROW, COL);
-	main_layers_pop_id(layer_ids[local_id]);
+  layer_pop(local_id);
 	// Only the topmost layer on the stack should be in sticky once state, pop
 	//  the top layer if it is in sticky once state
 	uint8_t topSticky = main_layers_peek_sticky(0);
@@ -120,7 +128,7 @@ static void layer_sticky(uint8_t local_id) {
 	if (IS_PRESSED) {
 		uint8_t topLayer = main_layers_peek(0);
 		uint8_t topSticky = main_layers_peek_sticky(0);
-		main_layers_pop_id(layer_ids[local_id]);
+    layer_pop(local_id);
 		if (topLayer == local_id) {
 			if (topSticky == eStickyOnceUp)
 				layer_ids[local_id] = main_layers_push(keycode, eStickyLock);
@@ -129,7 +137,7 @@ static void layer_sticky(uint8_t local_id) {
 		{
 			// only the topmost layer on the stack should be in sticky once state
 			if (topSticky == eStickyOnceDown || topSticky == eStickyOnceUp) {
-				main_layers_pop_id(layer_ids[topLayer]);
+        layer_pop(topLayer);
 			}
 			layer_ids[local_id] = main_layers_push(keycode, eStickyOnceDown);
 			// this should be the only place we care about this flag being cleared
@@ -143,7 +151,7 @@ static void layer_sticky(uint8_t local_id) {
 		if (topLayer == local_id) {
 			if (topSticky == eStickyOnceDown) {
 				// When releasing this sticky key, pop the layer always
-				main_layers_pop_id(layer_ids[local_id]);
+        layer_pop(local_id);
 				if (!main_arg_any_non_trans_key_pressed) {
 					// If no key defined for this layer (a non-transparent key)
 					//  was pressed, push the layer again, but in the
@@ -155,9 +163,14 @@ static void layer_sticky(uint8_t local_id) {
 	}
 }
 
-static void layer_pop(uint8_t local_id) {
-	main_layers_pop_id(layer_ids[local_id]);
-	layer_ids[local_id] = 0;
+static void layer_toggle(uint8_t local_id) {
+  if (layer_ids[local_id] != 0) {
+    layer_pop(local_id);
+  }
+  else
+  {
+    layer_push(local_id);
+  }
 }
 
 /*
@@ -197,7 +210,7 @@ void kbfun_layer_push_1(void) {
  *   for each state:
  *  1) One time down (set on key press) - The layer was not active and the key
  *      has been pressed but not yet released. The layer is pushed in the one
- *      time down state. 
+ *      time down state.
  *  2) One time up (set on key release) - The layer was active when the layer
  *      sticky key was released. If a key on this layer (not set to
  *      transparent) was pressed before the key was released, the layer will be
@@ -226,11 +239,22 @@ void kbfun_layer_pop_1(void) {
 
 /*
  * [name]
+ *   Layer toggle #1
+ *
+ * [description]
+ *   If the layer element is already in the layer stack, pop it.  Otherwise,
+ *   push the layer element to the top of the stack.
+ */
+void kbfun_layer_toggle_1(void) {
+	layer_toggle(1);
+}
+
+/*
+ * [name]
  *   Layer push #2
  *
  * [description]
- *   Push a layer element containing the layer value specified in the keymap to
- *   the top of the stack, and record the id of that layer element
+ *   See the description of kbfun_layer_push_1()
  */
 void kbfun_layer_push_2(void) {
 	layer_push(2);
@@ -252,9 +276,7 @@ void kbfun_layer_sticky_2  (void) {
  *   Layer pop #2
  *
  * [description]
- *   Pop the layer element created by the corresponding "layer push" function
- *   out of the layer stack (no matter where it is in the stack, without
- *   touching any other elements)
+ *   See the description of kbfun_layer_pop_1()
  */
 void kbfun_layer_pop_2(void) {
 	layer_pop(2);
@@ -262,11 +284,21 @@ void kbfun_layer_pop_2(void) {
 
 /*
  * [name]
+ *   Layer toggle #2
+ *
+ * [description]
+ *   See the description of kbfun_layer_toggle_1()
+ */
+void kbfun_layer_toggle_2(void) {
+	layer_toggle(2);
+}
+
+/*
+ * [name]
  *   Layer push #3
  *
  * [description]
- *   Push a layer element containing the layer value specified in the keymap to
- *   the top of the stack, and record the id of that layer element
+ *   See the description of kbfun_layer_push_1()
  */
 void kbfun_layer_push_3(void) {
 	layer_push(3);
@@ -288,9 +320,7 @@ void kbfun_layer_sticky_3  (void) {
  *   Layer pop #3
  *
  * [description]
- *   Pop the layer element created by the corresponding "layer push" function
- *   out of the layer stack (no matter where it is in the stack, without
- *   touching any other elements)
+ *   See the description of kbfun_layer_pop_1()
  */
 void kbfun_layer_pop_3(void) {
 	layer_pop(3);
@@ -298,11 +328,21 @@ void kbfun_layer_pop_3(void) {
 
 /*
  * [name]
+ *   Layer toggle #3
+ *
+ * [description]
+ *   See the description of kbfun_layer_toggle_1()
+ */
+void kbfun_layer_toggle_3(void) {
+	layer_toggle(3);
+}
+
+/*
+ * [name]
  *   Layer push #4
  *
  * [description]
- *   Push a layer element containing the layer value specified in the keymap to
- *   the top of the stack, and record the id of that layer element
+ *   See the description of kbfun_layer_push_1()
  */
 void kbfun_layer_push_4(void) {
 	layer_push(4);
@@ -324,9 +364,7 @@ void kbfun_layer_sticky_4  (void) {
  *   Layer pop #4
  *
  * [description]
- *   Pop the layer element created by the corresponding "layer push" function
- *   out of the layer stack (no matter where it is in the stack, without
- *   touching any other elements)
+ *   See the description of kbfun_layer_pop_1()
  */
 void kbfun_layer_pop_4(void) {
 	layer_pop(4);
@@ -334,11 +372,21 @@ void kbfun_layer_pop_4(void) {
 
 /*
  * [name]
+ *   Layer toggle #4
+ *
+ * [description]
+ *   See the description of kbfun_layer_toggle_1()
+ */
+void kbfun_layer_toggle_4(void) {
+	layer_toggle(4);
+}
+
+/*
+ * [name]
  *   Layer push #5
  *
  * [description]
- *   Push a layer element containing the layer value specified in the keymap to
- *   the top of the stack, and record the id of that layer element
+ *   See the description of kbfun_layer_push_1()
  */
 void kbfun_layer_push_5(void) {
 	layer_push(5);
@@ -360,9 +408,7 @@ void kbfun_layer_sticky_5  (void) {
  *   Layer pop #5
  *
  * [description]
- *   Pop the layer element created by the corresponding "layer push" function
- *   out of the layer stack (no matter where it is in the stack, without
- *   touching any other elements)
+ *   See the description of kbfun_layer_pop_1()
  */
 void kbfun_layer_pop_5(void) {
 	layer_pop(5);
@@ -370,11 +416,21 @@ void kbfun_layer_pop_5(void) {
 
 /*
  * [name]
+ *   Layer toggle #5
+ *
+ * [description]
+ *   See the description of kbfun_layer_toggle_1()
+ */
+void kbfun_layer_toggle_5(void) {
+	layer_toggle(5);
+}
+
+/*
+ * [name]
  *   Layer push #6
  *
  * [description]
- *   Push a layer element containing the layer value specified in the keymap to
- *   the top of the stack, and record the id of that layer element
+ *   See the description of kbfun_layer_push_1()
  */
 void kbfun_layer_push_6(void) {
 	layer_push(6);
@@ -396,9 +452,7 @@ void kbfun_layer_sticky_6  (void) {
  *   Layer pop #6
  *
  * [description]
- *   Pop the layer element created by the corresponding "layer push" function
- *   out of the layer stack (no matter where it is in the stack, without
- *   touching any other elements)
+ *   See the description of kbfun_layer_pop_1()
  */
 void kbfun_layer_pop_6(void) {
 	layer_pop(6);
@@ -406,11 +460,21 @@ void kbfun_layer_pop_6(void) {
 
 /*
  * [name]
+ *   Layer toggle #6
+ *
+ * [description]
+ *   See the description of kbfun_layer_toggle_1()
+ */
+void kbfun_layer_toggle_6(void) {
+	layer_toggle(6);
+}
+
+/*
+ * [name]
  *   Layer push #7
  *
  * [description]
- *   Push a layer element containing the layer value specified in the keymap to
- *   the top of the stack, and record the id of that layer element
+ *   See the description of kbfun_layer_push_1()
  */
 void kbfun_layer_push_7(void) {
 	layer_push(7);
@@ -432,9 +496,7 @@ void kbfun_layer_sticky_7  (void) {
  *   Layer pop #7
  *
  * [description]
- *   Pop the layer element created by the corresponding "layer push" function
- *   out of the layer stack (no matter where it is in the stack, without
- *   touching any other elements)
+ *   See the description of kbfun_layer_pop_1()
  */
 void kbfun_layer_pop_7(void) {
 	layer_pop(7);
@@ -442,11 +504,21 @@ void kbfun_layer_pop_7(void) {
 
 /*
  * [name]
+ *   Layer toggle #7
+ *
+ * [description]
+ *   See the description of kbfun_layer_toggle_1()
+ */
+void kbfun_layer_toggle_7(void) {
+	layer_toggle(7);
+}
+
+/*
+ * [name]
  *   Layer push #8
  *
  * [description]
- *   Push a layer element containing the layer value specified in the keymap to
- *   the top of the stack, and record the id of that layer element
+ *   See the description of kbfun_layer_push_1()
  */
 void kbfun_layer_push_8(void) {
 	layer_push(8);
@@ -468,9 +540,7 @@ void kbfun_layer_sticky_8  (void) {
  *   Layer pop #8
  *
  * [description]
- *   Pop the layer element created by the corresponding "layer push" function
- *   out of the layer stack (no matter where it is in the stack, without
- *   touching any other elements)
+ *   See the description of kbfun_layer_pop_1()
  */
 void kbfun_layer_pop_8(void) {
 	layer_pop(8);
@@ -478,11 +548,21 @@ void kbfun_layer_pop_8(void) {
 
 /*
  * [name]
+ *   Layer toggle #8
+ *
+ * [description]
+ *   See the description of kbfun_layer_toggle_1()
+ */
+void kbfun_layer_toggle_8(void) {
+	layer_toggle(8);
+}
+
+/*
+ * [name]
  *   Layer push #9
  *
  * [description]
- *   Push a layer element containing the layer value specified in the keymap to
- *   the top of the stack, and record the id of that layer element
+ *   See the description of kbfun_layer_push_1()
  */
 void kbfun_layer_push_9(void) {
 	layer_push(9);
@@ -504,9 +584,7 @@ void kbfun_layer_sticky_9  (void) {
  *   Layer pop #9
  *
  * [description]
- *   Pop the layer element created by the corresponding "layer push" function
- *   out of the layer stack (no matter where it is in the stack, without
- *   touching any other elements)
+ *   See the description of kbfun_layer_pop_1()
  */
 void kbfun_layer_pop_9(void) {
 	layer_pop(9);
@@ -514,11 +592,21 @@ void kbfun_layer_pop_9(void) {
 
 /*
  * [name]
+ *   Layer toggle #9
+ *
+ * [description]
+ *   See the description of kbfun_layer_toggle_1()
+ */
+void kbfun_layer_toggle_9(void) {
+	layer_toggle(9);
+}
+
+/*
+ * [name]
  *   Layer push #10
  *
  * [description]
- *   Push a layer element containing the layer value specified in the keymap to
- *   the top of the stack, and record the id of that layer element
+ *   See the description of kbfun_layer_push_1()
  */
 void kbfun_layer_push_10(void) {
 	layer_push(10);
@@ -540,12 +628,21 @@ void kbfun_layer_sticky_10  (void) {
  *   Layer pop #10
  *
  * [description]
- *   Pop the layer element created by the corresponding "layer push" function
- *   out of the layer stack (no matter where it is in the stack, without
- *   touching any other elements)
+ *   See the description of kbfun_layer_pop_1()
  */
 void kbfun_layer_pop_10(void) {
 	layer_pop(10);
+}
+
+/*
+ * [name]
+ *   Layer toggle #10
+ *
+ * [description]
+ *   See the description of kbfun_layer_toggle_1()
+ */
+void kbfun_layer_toggle_10(void) {
+	layer_toggle(10);
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/lib/key-functions/public/basic.c
+++ b/src/lib/key-functions/public/basic.c
@@ -104,16 +104,16 @@ void kbfun_transparent(void) {
 static uint8_t layer_ids[1 + MAX_LAYER_PUSH_POP_FUNCTIONS];
 
 static void layer_pop(uint8_t local_id) {
-  uint8_t id = layer_ids[local_id];
-  if (id != 0) {
-    main_layers_pop_id(id);
-	  layer_ids[local_id] = 0;
-  }
+	uint8_t id = layer_ids[local_id];
+	if (id != 0) {
+		main_layers_pop_id(id);
+		layer_ids[local_id] = 0;
+	}
 }
 
 static void layer_push(uint8_t local_id) {
 	uint8_t keycode = kb_layout_get(LAYER, ROW, COL);
-  layer_pop(local_id);
+	layer_pop(local_id);
 	// Only the topmost layer on the stack should be in sticky once state, pop
 	//  the top layer if it is in sticky once state
 	uint8_t topSticky = main_layers_peek_sticky(0);
@@ -128,7 +128,7 @@ static void layer_sticky(uint8_t local_id) {
 	if (IS_PRESSED) {
 		uint8_t topLayer = main_layers_peek(0);
 		uint8_t topSticky = main_layers_peek_sticky(0);
-    layer_pop(local_id);
+		layer_pop(local_id);
 		if (topLayer == local_id) {
 			if (topSticky == eStickyOnceUp)
 				layer_ids[local_id] = main_layers_push(keycode, eStickyLock);
@@ -137,7 +137,7 @@ static void layer_sticky(uint8_t local_id) {
 		{
 			// only the topmost layer on the stack should be in sticky once state
 			if (topSticky == eStickyOnceDown || topSticky == eStickyOnceUp) {
-        layer_pop(topLayer);
+				layer_pop(topLayer);
 			}
 			layer_ids[local_id] = main_layers_push(keycode, eStickyOnceDown);
 			// this should be the only place we care about this flag being cleared
@@ -151,7 +151,7 @@ static void layer_sticky(uint8_t local_id) {
 		if (topLayer == local_id) {
 			if (topSticky == eStickyOnceDown) {
 				// When releasing this sticky key, pop the layer always
-        layer_pop(local_id);
+				layer_pop(local_id);
 				if (!main_arg_any_non_trans_key_pressed) {
 					// If no key defined for this layer (a non-transparent key)
 					//  was pressed, push the layer again, but in the
@@ -164,13 +164,13 @@ static void layer_sticky(uint8_t local_id) {
 }
 
 static void layer_toggle(uint8_t local_id) {
-  if (layer_ids[local_id] != 0) {
-    layer_pop(local_id);
-  }
-  else
-  {
-    layer_push(local_id);
-  }
+	if (layer_ids[local_id] != 0) {
+		layer_pop(local_id);
+	}
+	else
+	{
+		layer_push(local_id);
+	}
 }
 
 /*

--- a/src/main.c
+++ b/src/main.c
@@ -250,43 +250,22 @@ uint8_t main_layers_push(uint8_t layer, uint8_t sticky) {
  */
 void main_layers_pop_id(uint8_t id) {
 	// look for the element with the id we want to pop
-	for (uint8_t element=1; element<=layers_head; element++)
+	for (uint8_t element=1; element<=layers_head; element++) {
 		// if we find it
 		if (layers[element].id == id) {
-			// move all layers above it down one
-			for (; element<layers_head; element++) {
-				layers[element].layer = layers[element+1].layer;
-				layers[element].id = layers[element+1].id;
-			}
-			// reinitialize the topmost (now unused) slot
-			layers[layers_head].layer = 0;
-			layers[layers_head].id = 0;
-			// record keeping
-			layers_ids_in_use[id] = false;
-			layers_head--;
-		}
-}
-
-/*
- * get_offset_id()
- *
- * Arguments
- * - 'id': the id of the element you want the offset of
- *
- * Returns
- * - success: the offset (down the stack from the head element) of the element
- *   with the given id
- * - failure: 0 (default) (id unassigned)
- */
-uint8_t main_layers_get_offset_id(uint8_t id) {
-	// look for the element with the id we want to get the offset of
-	for (uint8_t element=1; element<=layers_head; element++)
-		// if we find it
-		if (layers[element].id == id)
-			return (layers_head - element);
-
-	return 0;  // default, or error
-
+            for(; element<layers_head; ++element) {
+                layers[element].layer = layers[element+1].layer;
+                layers[element].id = layers[element+1].id;
+            }
+            // reinitialize the topmost (now unused) slot
+            layers[layers_head].layer = 0;
+            layers[layers_head].id = 0;
+            // record keeping
+            layers_ids_in_use[id] = false;
+            layers_head--;
+            return;
+        }
+    }
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/main.c
+++ b/src/main.c
@@ -253,19 +253,19 @@ void main_layers_pop_id(uint8_t id) {
 	for (uint8_t element=1; element<=layers_head; element++) {
 		// if we find it
 		if (layers[element].id == id) {
-            for(; element<layers_head; ++element) {
-                layers[element].layer = layers[element+1].layer;
-                layers[element].id = layers[element+1].id;
-            }
-            // reinitialize the topmost (now unused) slot
-            layers[layers_head].layer = 0;
-            layers[layers_head].id = 0;
-            // record keeping
-            layers_ids_in_use[id] = false;
-            layers_head--;
-            return;
-        }
-    }
+			for(; element<layers_head; ++element) {
+				layers[element].layer = layers[element+1].layer;
+				layers[element].id = layers[element+1].id;
+			}
+			// reinitialize the topmost (now unused) slot
+			layers[layers_head].layer = 0;
+			layers[layers_head].id = 0;
+			// record keeping
+			layers_ids_in_use[id] = false;
+			layers_head--;
+			return;
+		}
+	}
 }
 
 /* ----------------------------------------------------------------------------

--- a/src/makefile-options
+++ b/src/makefile-options
@@ -9,7 +9,7 @@
 
 TARGET   := firmware  # the name we want for our program binary
 KEYBOARD := ergodox   # keyboard model; see "src/keyboard" for what's available
-LAYOUT   := qwerty-kinesis-mod  # keyboard layout
+LAYOUT   := workman-p-kinesis-mod  # keyboard layout
 				# see "src/keyboard/*/layout" for what's
 				# available
 


### PR DESCRIPTION
I added the toggle feature because of a scenario that was just impractical to workaround.

A layer that is momentary (only there while holding a key) needed a key within it that toggled another layer on/off when pressed.  Simulating this. within a momentary layer, was simply impractical.  Full changes listed below.

- Added layer "toggle" feature (instead of just push/pop), so people don't have to simulate it anymore
- Removed unused function main_layers_get_offset_id, it didn't seem to have much of a purpose anyway given how things are currently designed with local vs real IDs
- Slightly optimized layer_pop to keep from pointlessly iterating over the layer stack for layers we know aren't there (because their local id doesn't map to a real id)
- Slightly optimized layer_push by making it use the slightly optimized layer_pop.
- Because a given layer id (not to be confused with a 'layer' itself) can only be in the layer stack once, added a return in the main layer pop once it finds one entry
- Made documentation more consistent in kbfun_* functions
- Fixed whitespace in workman-p layout, converted to use toggles, and added an extra toggle to swap backspace and space (useful for a few buggy games that won't let you bind backspace, such as Dirty Bomb).