### PR TITLE
Ergodox layout macros

### DIFF
--- a/src/keyboard/ergodox/layout/ergodox-layout-impl-press.h
+++ b/src/keyboard/ergodox/layout/ergodox-layout-impl-press.h
@@ -1,0 +1,41 @@
+/*
+ * Redefines macros to implement the table of key press functions.
+ *
+ * Created by lotem <chen.sst@gmail.com>  2015-12-01
+ *
+ * Immediately following this file, again #include "your-ergodox-layout.h"
+ */
+
+#undef  UNUSED
+#undef  __
+#undef  _
+#undef  M
+#undef  S
+#undef  S2CAP
+#undef  STICKY
+#undef  CHORD
+#undef  PUSH
+#undef  POP
+#undef  PUSHNUM
+#undef  POPNUM
+#undef  POPALL
+#undef  BOOTLOADER
+
+#define  UNUSED     NULL
+#define  __         &kbfun_transparent
+#define  _(x)       &kbfun_press_release
+#define  M(x)       &kbfun_mediakey_press_release
+#define  S(x)       &kbfun_shift_press_release
+#define  S2CAP(x)   &kbfun_2_keys_capslock_press_release
+#define  STICKY(n)  &kbfun_layer_sticky_##n
+#define  CHORD(n)   &kbfun_layer_push_##n
+#define  PUSH(n)    &kbfun_layer_push_##n
+#define  POP(n)     &kbfun_layer_pop_##n
+#define  PUSHNUM(n) &kbfun_layer_push_numpad
+#define  POPNUM(n)  &kbfun_layer_pop_numpad
+#define  POPALL     &kbfun_layer_pop_all
+#define  BOOTLOADER &kbfun_jump_to_bootloader
+
+#undef ERGODOX_LAYOUT
+#define ERGODOX_LAYOUT const void_funptr_t PROGMEM _kb_layout_press[KB_LAYERS][KB_ROWS][KB_COLUMNS]
+

--- a/src/keyboard/ergodox/layout/ergodox-layout-impl-release.h
+++ b/src/keyboard/ergodox/layout/ergodox-layout-impl-release.h
@@ -1,0 +1,26 @@
+/*
+ * Redefines macros to implement the table of key release functions.
+ *
+ * Created by lotem <chen.sst@gmail.com>  2015-12-01
+ *
+ * Immediately following this file, again #include "your-ergodox-layout.h"
+ */
+
+#undef  CHORD
+#undef  PUSH
+#undef  POP
+#undef  PUSHNUM
+#undef  POPNUM
+#undef  POPALL
+#undef  BOOTLOADER
+
+#define  CHORD(n)   &kbfun_layer_pop_##n
+#define  PUSH(n)    NULL
+#define  POP(n)     NULL
+#define  PUSHNUM(n) NULL
+#define  POPNUM(n)  NULL
+#define  POPALL     NULL
+#define  BOOTLOADER NULL
+
+#undef ERGODOX_LAYOUT
+#define ERGODOX_LAYOUT const void_funptr_t PROGMEM _kb_layout_release[KB_LAYERS][KB_ROWS][KB_COLUMNS]

--- a/src/keyboard/ergodox/layout/ergodox-layout-impl.h
+++ b/src/keyboard/ergodox/layout/ergodox-layout-impl.h
@@ -1,0 +1,116 @@
+/*
+ * Implements an ergodox layout defined with the ERGODOX_LAYOUT macro.
+ *
+ * Created by lotem <chen.sst@gmail.com>  2015-12-01
+ *
+ * Usage:
+ * Create a header file named "your-ergodox-layout.h", with the following
+ * layout definition:
+ *
+ *     ERGODOX_LAYOUT = {
+ *       ERGODOX_LAYER(
+ *         // Define all the keys in the ergodox keyboard.
+ *       ),
+ *       // Repeat the ERGODOX_LAYER macro to add more layers.
+ *     };
+ *
+ * Then in "your-ergodox-mod.c":
+ *
+ *     #include "ergodox-layout-impl.h"
+ *     #include "your-ergodox-layout.h"
+ *
+ *     #include "ergodox-layout-impl-press.h"
+ *     #include "your-ergodox-layout.h"
+ *
+ *     #include "ergodox-layout-impl-release.h"
+ *     #include "your-ergodox-layout.h"
+ */
+
+/* Defines a keyboard layer. */
+#define ERGODOX_LAYER( \
+  /* left hand, spatial positions */ \
+  k50,k51,k52,k53,k54,k55,k56, \
+  k40,k41,k42,k43,k44,k45,k46, \
+  k30,k31,k32,k33,k34,k35, \
+  k20,k21,k22,k23,k24,k25,k26, \
+  k10,k11,k12,k13,k14, \
+                      k05,k06, \
+                          k04, \
+                  k03,k02,k01, \
+ \
+  /* right hand, spatial positions */ \
+  k57,k58,k59,k5A,k5B,k5C,k5D, \
+  k47,k48,k49,k4A,k4B,k4C,k4D, \
+      k38,k39,k3A,k3B,k3C,k3D, \
+  k27,k28,k29,k2A,k2B,k2C,k2D, \
+          k19,k1A,k1B,k1C,k1D, \
+  k07,k08, \
+  k09, \
+  k0C,k0B,k0A) \
+/* matrix */ \
+{ \
+  { 0,  k01,k02,k03,k04,k05,k06,k07,k08,k09,k0A,k0B,k0C,0   }, \
+  { k10,k11,k12,k13,k14,0,  0,  0,  0,  k19,k1A,k1B,k1C,k1D }, \
+  { k20,k21,k22,k23,k24,k25,k26,k27,k28,k29,k2A,k2B,k2C,k2D }, \
+  { k30,k31,k32,k33,k34,k35,0,  0,  k38,k39,k3A,k3B,k3C,k3D }, \
+  { k40,k41,k42,k43,k44,k45,k46,k47,k48,k49,k4A,k4B,k4C,k4D }, \
+  { k50,k51,k52,k53,k54,k55,k56,k57,k58,k59,k5A,k5B,k5C,k5D } \
+}
+
+/*
+ * Macros used in the layout file to define individual keys.
+ *
+ * The following key macros are used as parameters to ERGODOX_LAYER to fill
+ * the key code table.
+ * They will be redefined later to implement the key press and release tables
+ * respectively.
+ *
+ *     UNUSED      Unused key.
+ *     __          Transparent; fallback to the previous layer.
+ *     _(x)        Normal key.
+ *     M(x)        Media key. Shorten the key name for easier alignment.
+ *     S(x)        Key that automatically has the Shift modifier on.
+ *     S2CAP(x)    Key that yields caps lock when two of the same keys are pressed.
+ *     STICKY(n)   Stikey layer key.
+ *     CHORD(n)    Chorded layer key.
+ *     PUSH(n)     Push the specified layer.
+ *     POP(n)      Pop the specified layer.
+ *     PUSHNUM(n)  Push numpad layer.
+ *     POPNUM(n)   Pop numpad layer.
+ *     POPALL      Pop all layers.
+ *     BOOTLOADER  Trigger bootloader.
+ */
+
+#undef  UNUSED
+#undef  __
+#undef  _
+#undef  M
+#undef  S
+#undef  S2CAP
+#undef  STICKY
+#undef  CHORD
+#undef  PUSH
+#undef  POP
+#undef  PUSHNUM
+#undef  POPNUM
+#undef  POPALL
+#undef  BOOTLOADER
+
+#define  UNUSED     0
+#define  __         0
+#define  _(x)       x
+#define  M(x)       MEDIAKEY_##x
+#define  S(x)       x
+#define  S2CAP(x)   x
+#define  STICKY(n)  n
+#define  CHORD(n)   n
+#define  PUSH(n)    n
+#define  POP(n)     n
+#define  PUSHNUM(n) n
+#define  POPNUM(n)  n
+#define  POPALL     0
+#define  BOOTLOADER 0
+
+/* Defines the key code table. */
+#define ERGODOX_LAYOUT const uint8_t PROGMEM _kb_layout[KB_LAYERS][KB_ROWS][KB_COLUMNS]
+

--- a/src/keyboard/ergodox/layout/sample-layout.h
+++ b/src/keyboard/ergodox/layout/sample-layout.h
@@ -1,0 +1,48 @@
+/*
+ * Ergodox layout: sample
+ * Based on qwerty-kinesis-mod
+ *
+ * Created by lotem <chen.sst@gmail.com>
+ */
+ERGODOX_LAYOUT = {
+  ERGODOX_LAYER( // L0: default
+    // left hand
+    _(_equal),      _(_1),          _(_2),          _(_3),          _(_4),          _(_5),          _(_esc),
+    _(_backslash),  _(_Q),          _(_W),          _(_E),          _(_R),          _(_T),          PUSH(1),
+    _(_tab),        _(_A),          _(_S),          _(_D),          _(_F),          _(_G),
+    S2CAP(_shiftL), _(_Z),          _(_X),          _(_C),          _(_V),          _(_B),          CHORD(1),
+    _(_guiL),       _(_grave),      _(_backslash),  _(_arrowL),     _(_arrowR),
+                                                                                    _(_ctrlL),      _(_altL),
+                                                                                                    _(_home),
+                                                                    _(_bs),         _(_del),        _(_end),
+    // right hand
+    UNUSED,         _(_6),          _(_7),          _(_8),          _(_9),          _(_0),          _(_dash),
+    _(_bracketL),   _(_Y),          _(_U),          _(_I),          _(_O),          _(_P),          _(_bracketR),
+    /*_*/           _(_H),          _(_J),          _(_K),          _(_L),          _(_semicolon),  _(_quote),
+    CHORD(1),       _(_N),          _(_M),          _(_comma),      _(_period),     _(_slash),      S2CAP(_shiftR),
+                                    _(_arrowL),     _(_arrowD),     _(_arrowU),     _(_arrowR),     _(_guiR),
+    _(_altR),       _(_ctrlR),
+    _(_pageU),
+    _(_pageD),      _(_enter),      _(_space)
+  ),
+  ERGODOX_LAYER( // L1: function and symbol keys
+    // left hand
+    __,             _(_F1),         _(_F2),         _(_F3),         _(_F4),         _(_F5),         _(_F11),
+    __,             S(_bracketL),   S(_bracketR),   _(_bracketL),   _(_bracketR),   UNUSED,         POP(1),
+    __,             _(_semicolon),  _(_slash),      _(_dash),       _(_0_kp),       S(_semicolon),
+    __,             _(_6_kp),       _(_7_kp),       _(_8_kp),       _(_9_kp),       S(_equal),      __,
+    __,             __,            __,             __,              __,
+                                                                                    __,             __,
+                                                                                                    __,
+                                                                    __,             __,             __,
+    // right hand
+    _(_F12),        _(_F6),         _(_F7),         _(_F8),         _(_F9),         _(_F10),        _(_power),
+    __,             UNUSED,         S(_dash),       S(_comma),      S(_period),     _(_currencyUnit), _(_volumeU),
+                    _(_backslash),  _(_1_kp),       S(_9),          S(_0),          _(_equal),      _(_volumeD),
+    __,             S(_8),          _(_2_kp),       _(_3_kp),       _(_4_kp),       _(_5_kp),       _(_mute),
+                                    __,             __,             __,             __,             __,
+    __,             __,
+    __,
+    __,             __,             __
+  ),
+};

--- a/src/keyboard/ergodox/layout/sample-mod.c
+++ b/src/keyboard/ergodox/layout/sample-mod.c
@@ -1,0 +1,43 @@
+/* ----------------------------------------------------------------------------
+ * Ergodox layout sample
+ * Revised by lotem <chen.sst@gmail.com>
+ * ----------------------------------------------------------------------------
+ * Copyright (c) 2012 Ben Blazak <benblazak.dev@gmail.com>,
+ *    2013 Ryan Prince <judascleric@gmail.com>
+ * Released under The MIT License (MIT) (see "license.md")
+ * Project located at <https://github.com/benblazak/ergodox-firmware>
+ * ------------------------------------------------------------------------- */
+#include <stdint.h>
+#include <stddef.h>
+#include <avr/pgmspace.h>
+#include "../../../lib/data-types/misc.h"
+#include "../../../lib/key-functions/public.h"
+#include "../../../lib/usb/usage-page/keyboard--short-names.h"
+#include "../matrix.h"
+#include "../layout.h"
+
+void kbfun_layer_pop_all(void) {
+  kbfun_layer_pop_1();
+  kbfun_layer_pop_2();
+  kbfun_layer_pop_3();
+  kbfun_layer_pop_4();
+  kbfun_layer_pop_5();
+  kbfun_layer_pop_6();
+  kbfun_layer_pop_7();
+  kbfun_layer_pop_8();
+  kbfun_layer_pop_9();
+  kbfun_layer_pop_10();
+}
+
+#include "ergodox-layout-impl.h"
+/* TODO: change to your layout file. */
+#include "sample-layout.h"
+
+#include "ergodox-layout-impl-press.h"
+/* TODO: change to your layout file. */
+#include "sample-layout.h"
+
+#include "ergodox-layout-impl-release.h"
+/* TODO: change to your layout file. */
+#include "sample-layout.h"
+

--- a/src/keyboard/ergodox/layout/sample-mod.h
+++ b/src/keyboard/ergodox/layout/sample-mod.h
@@ -1,0 +1,30 @@
+/* ----------------------------------------------------------------------------
+ * Ergodox layout sample
+ * Revised by lotem <chen.sst@gmail.com>
+ * ----------------------------------------------------------------------------
+ * Copyright (c) 2012 Ben Blazak <benblazak.dev@gmail.com>
+ * Released under The MIT License (MIT) (see "license.md")
+ * Project located at <https://github.com/benblazak/ergodox-firmware>
+ * ------------------------------------------------------------------------- */
+
+
+#ifndef KEYBOARD__ERGODOX__LAYOUT__SAMPLE_h
+#define KEYBOARD__ERGODOX__LAYOUT__SAMPLE_h
+
+#include "../controller.h"
+
+// --------------------------------------------------------------------
+
+#define kb_led_num_on()      _kb_led_1_on()
+#define kb_led_num_off()     _kb_led_1_off()
+#define kb_led_caps_on()     _kb_led_2_on()
+#define kb_led_caps_off()    _kb_led_2_off()
+#define kb_led_scroll_on()   _kb_led_3_on()
+#define kb_led_scroll_off()  _kb_led_3_off()
+
+// --------------------------------------------------------------------
+
+#include "./default--led-control.h"
+#include "./default--matrix-control.h"
+
+#endif

--- a/src/makefile-options
+++ b/src/makefile-options
@@ -9,7 +9,7 @@
 
 TARGET   := firmware  # the name we want for our program binary
 KEYBOARD := ergodox   # keyboard model; see "src/keyboard" for what's available
-LAYOUT   := qwerty-kinesis-mod  # keyboard layout
+LAYOUT   := sample-mod  # keyboard layout
 				# see "src/keyboard/*/layout" for what's
 				# available
 


### PR DESCRIPTION
Hi there. I have a bit of code that might interest you.

I'm thankful of people who created and shared their Ergodox layout code that helps me get started and evolve my own. In the process of tweaking the keyboard, I find myself not only rearranging keys within the alphabet zone, but also frequently moving function keys and layer switching keys around. Having to carefully edit several places to get one key right truly annoys me. As a try to fix that, I created a set of helper macros to generate the arrays for key codes, press and release functions.

The philosophy of this PR is to keep any change to a key in one place, namely `xxx-layout.h`.
This header file, with layout definition in `ERGODOX_LAYOUT` macro, is included three times into the C module, each given a different set of key-defining macros.
The nice part is you can write the three values associated to a key all in one place, eg. `S(_equal)` for a `+` key; you never have to scroll down to know that it comes with a combined Shift. This I believe leads to shorter, more readable and less error-prone code.

I've created a sample layout with this feature, an incomplete rewrite of qwerty-kinesis-mod, just to give you a taste.
If you do think it helpful to others as well, please give comments on how this PR can be improved for inclusion.
Thanks.
