### PR TITLE
Send all keycodes beyond the basic 104 keys so f13-f24 etc work

### DIFF
--- a/src/lib-other/pjrc/usb_keyboard/usb_keyboard.c
+++ b/src/lib-other/pjrc/usb_keyboard/usb_keyboard.c
@@ -140,10 +140,10 @@ static const uint8_t PROGMEM keyboard_hid_report_desc[] = {
         0x95, 0x06,          //   Report Count (6),
         0x75, 0x08,          //   Report Size (8),
         0x15, 0x00,          //   Logical Minimum (0),
-        0x25, 0x68,          //   Logical Maximum(104),
+        0x25, 0xff,          //   Logical Maximum(255),
         0x05, 0x07,          //   Usage Page (Key Codes),
         0x19, 0x00,          //   Usage Minimum (0),
-        0x29, 0x68,          //   Usage Maximum (104),
+        0x29, 0xff,          //   Usage Maximum (255),
         0x81, 0x00,          //   Input (Data, Array),
         0xc0                 // End Collection
 };


### PR DESCRIPTION
Had the same problem as https://github.com/benblazak/ergodox-firmware/issues/66, with F14 and up not working. I checked the TMK firmware and noticed this relevant difference. Changed it, everything works now. :)
