### PR TITLE
adding a feature that shows current layer number in binary

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,8 @@
 
 // ----------------------------------------------------------------------------
 
+uint8_t layers_head = 0;
+
 static bool _main_kb_is_pressed[KB_ROWS][KB_COLUMNS];
 bool (*main_kb_is_pressed)[KB_ROWS][KB_COLUMNS] = &_main_kb_is_pressed;
 
@@ -131,6 +133,30 @@ int main(void) {
 		else { kb_led_compose_off(); }
 		if (keyboard_leds & (1<<4)) { kb_led_kana_on(); }
 		else { kb_led_kana_off(); }
+
+
+#ifdef LEDS_SHOW_LAYER_IN_BINARY
+		if (layers_head!=0) {
+
+		  kb_led_num_off();
+		  kb_led_caps_off();
+		  kb_led_scroll_off();
+
+		  if (layers_head&(1<<0))
+		    kb_led_scroll_on();
+		  if (layers_head&(1<<1))
+		    kb_led_caps_on();
+		  if (layers_head&(1<<2))
+		    kb_led_num_on();
+		  
+		}
+		else {
+		  kb_led_num_off();
+		  kb_led_caps_off();
+		  kb_led_scroll_off();
+		}
+#endif
+
 	}
 
 	return 0;
@@ -168,7 +194,6 @@ struct layers {
 // ----------------------------------------------------------------------------
 
 struct layers layers[MAX_ACTIVE_LAYERS];
-uint8_t       layers_head = 0;
 uint8_t       layers_ids_in_use[MAX_ACTIVE_LAYERS] = {true};
 
 /*

--- a/src/makefile
+++ b/src/makefile
@@ -20,6 +20,7 @@ MCU    := atmega32u4  # processor type (for teensy 2.0); must match real life
 BOARD  := teensy-2-0  # see the libraries you're using for what's available
 F_CPU  := 16000000    # processor speed, in Hz
 
+#if set to true, the num,scroll,caps LED's will display current layer number in binary
 # firmware stuff
 SRC  := $(wildcard *.c)
 # keyboard and layout stuff
@@ -47,9 +48,10 @@ SRC += $(wildcard lib-other/*/*/*.c)
 
 OBJ = $(SRC:%.c=%.o)
 
+CFLAGS := -DLEDS_SHOW_LAYER_IN_BINARY=
 
 # . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
-CFLAGS := -mmcu=$(MCU)      # processor type (teensy 2.0); must match real
+CFLAGS += -mmcu=$(MCU)      # processor type (teensy 2.0); must match real
 			    #   life
 CFLAGS += -DF_CPU=$(F_CPU)  # processor frequency; must match initialization
 			    #   in source


### PR DESCRIPTION
I built it for my Ergodox EZ - the scroll,num,caps lock LED's are all on the top and I like to know what layer I'm on (without having to own Ergodox Infinity).
There's a new #define in makefile - DLEDS_SHOW_LAYER_IN_BINARY  - set by default to false, setting it to true triggers the new code converting layer number to binary and displaying it using the LED's