### PR TITLE
lib: Fix num pad behavior on GNU/Linux.

### DIFF
--- a/src/lib/key-functions/public/special.c
+++ b/src/lib/key-functions/public/special.c
@@ -102,9 +102,9 @@ void kbfun_2_keys_capslock_press_release(void) {
 static uint8_t numpad_layer_id;
 
 static inline void numpad_toggle_numlock(void) {
-	_kbfun_press_release(true, KEY_LockingNumLock);
+	_kbfun_press_release(true, KEYPAD_NumLock_Clear);
 	usb_keyboard_send();
-	_kbfun_press_release(false, KEY_LockingNumLock);
+	_kbfun_press_release(false, KEYPAD_NumLock_Clear);
 	usb_keyboard_send();
 }
 


### PR DESCRIPTION
The KEY_LockingNumLock locking version is obsolete and not supported on GNU/Linux.  Use the more modern KEYPAD_NumLock_Clear equivalent instead.

* src/lib/key-functions/public/special.c (numpad_toggle_numlock): Replace KEY_LockingNumLock with KEYPAD_NumLock_Clear.